### PR TITLE
Add file locking for memory writes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ requests
 PyPDF2
 python-docx
 fpdf
+filelock
 


### PR DESCRIPTION
## Summary
- protect memory updates with FileLock to avoid concurrent writes
- add filelock dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685d41760ba08322bc8b041731c0dea3