### PR TITLE
Add per-user memory logs

### DIFF
--- a/install_jarvik.sh
+++ b/install_jarvik.sh
@@ -20,6 +20,23 @@ if [ ! -f memory/public.jsonl ]; then
   touch memory/public.jsonl
 fi
 
+# Create personal memory logs for users defined in users.json
+if [ -f users.json ]; then
+  echo "📄 Vytvářím osobní paměti pro uživatele..."
+  python - <<'PY'
+import json, os
+with open('users.json', 'r', encoding='utf-8') as f:
+    data = json.load(f)
+for u in data:
+    nick = u.get('nick')
+    if not nick:
+        continue
+    path = os.path.join('memory', nick)
+    os.makedirs(path, exist_ok=True)
+    open(os.path.join(path, 'log.jsonl'), 'a', encoding='utf-8').close()
+PY
+fi
+
 # Vytvoření virtuálního prostředí (pokud není)
 if [ ! -d venv ]; then
   echo "🧪 Vytvářím virtuální prostředí venv/..."


### PR DESCRIPTION
## Summary
- keep conversation history in a personal `memory/<nick>/log.jsonl`
- read both personal and public memories when available
- create user subdirectories from `users.json` during install
- adjust tests for the new memory layout

## Testing
- `ruff check main.py tests/test_flask_app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685d81e71f948322bfeb009ed1bc5251