### PR TITLE
Add per-user knowledge bases

### DIFF
--- a/rag_engine.py
+++ b/rag_engine.py
@@ -125,16 +125,22 @@ def search_knowledge(query, knowledge_chunks, threshold=0.6):
 
 
 class KnowledgeBase:
-    """Manage loading and searching local knowledge files."""
+    """Manage loading and searching local knowledge files from one or more folders."""
 
-    def __init__(self, folder: str):
-        self.folder = folder
+    def __init__(self, folder: str | list[str]):
+        if isinstance(folder, str):
+            self.folders = [folder]
+        else:
+            self.folders = list(folder)
         self.chunks: list[str] = []
         self.reload()
 
     def reload(self) -> None:
-        """(Re)load all supported files from :attr:`folder`."""
-        self.chunks = _load_folder(self.folder)
+        """(Re)load all supported files from :attr:`folders`."""
+        chunks: list[str] = []
+        for folder in self.folders:
+            chunks.extend(_load_folder(folder))
+        self.chunks = chunks
 
     def search(self, query: str, threshold: float | None = None) -> list[str]:
         """Search loaded chunks for *query* using :func:`search_knowledge`.

--- a/tests/test_flask_app.py
+++ b/tests/test_flask_app.py
@@ -39,6 +39,7 @@ def client(monkeypatch, tmp_path):
 
     # Replace the global knowledge instance
     main.knowledge = DummyKB()
+    main.user_knowledge = {}
 
     # Isolate memory handling
     monkeypatch.setattr(main, "MEMORY_DIR", str(tmp_path))

--- a/tests/test_rag_engine.py
+++ b/tests/test_rag_engine.py
@@ -114,3 +114,17 @@ def test_knowledge_base_env_threshold(monkeypatch, knowledge_dir):
     # A very low threshold returns results based on similarity ratio
     monkeypatch.setenv("RAG_THRESHOLD", "0.2")
     assert kb.search("nonsense") != []
+
+
+def test_knowledge_base_multiple_folders(tmp_path):
+    folder1 = tmp_path / "kb1"
+    folder2 = tmp_path / "kb2"
+    folder1.mkdir()
+    folder2.mkdir()
+    (folder1 / "a.txt").write_text("hello", encoding="utf-8")
+    (folder2 / "b.txt").write_text("world", encoding="utf-8")
+
+    kb = KnowledgeBase([str(folder1), str(folder2)])
+
+    assert any("hello" in c for c in kb.chunks)
+    assert any("world" in c for c in kb.chunks)


### PR DESCRIPTION
## Summary
- extend `KnowledgeBase` to load from multiple folders
- create helper in `main.py` to get a user-specific knowledge base
- use the helper in `/ask`, `/ask_file`, `/knowledge/search` and `/knowledge/reload`
- update Flask tests and add new unit test for multi-folder support

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_685d8365fb808322b86957d4db2be3f6