### PR TITLE
Add user creation helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,15 @@ Generate the `password_hash` value with:
 python -c "import auth; print(auth.hash_password('your_password'))"
 ```
 
+### Adding users via helper script
+
+Run `tools/create_user.py` to append a new account to `users.json`. Existing
+nicks are skipped and the file is created automatically when missing.
+
+```bash
+python tools/create_user.py --nick bob --password pw
+```
+
 The repository also includes a `users.example.json` file containing the same
 sample for quick reference.
 

--- a/tools/create_user.py
+++ b/tools/create_user.py
@@ -1,0 +1,44 @@
+import argparse
+import getpass
+import json
+import os
+
+import auth
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+USERS_FILE = os.path.join(BASE_DIR, "users.json")
+
+
+def load_users() -> list[dict]:
+    if not os.path.exists(USERS_FILE):
+        return []
+    with open(USERS_FILE, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def save_users(users: list[dict]) -> None:
+    with open(USERS_FILE, "w", encoding="utf-8") as fh:
+        json.dump(users, fh, indent=2)
+        fh.write("\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Add a user to users.json")
+    parser.add_argument("--nick")
+    parser.add_argument("--password")
+    args = parser.parse_args()
+
+    nick = args.nick or input("Nick: ")
+    password = args.password or getpass.getpass("Password: ")
+
+    users = load_users()
+    if any(u.get("nick") == nick for u in users):
+        parser.error(f"User '{nick}' already exists")
+
+    users.append({"nick": nick, "password_hash": auth.hash_password(password)})
+    save_users(users)
+    print(f"User '{nick}' added to {USERS_FILE}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a `tools/create_user.py` utility to manage `users.json`
- document the helper in the Authentication section of README

## Testing
- `pytest -q`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_b_685e1f2cec688322886e2e5d0dcf9ce0