### PR TITLE
Add token display with copy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,8 @@ obtain a token from the `/login` endpoint. The token is stored in
 An optional API key field is provided and saved in `localStorage` as well. If
 `users.json` is missing authentication is disabled and the interface loads
 immediately.
+The token is shown in the web interface and can be copied with a button after
+logging in.
 
 ## Running Tests
 

--- a/static/index.html
+++ b/static/index.html
@@ -89,6 +89,9 @@
   <button onclick="switchModel()">Switch model</button>
   <pre id="model-status"></pre>
 
+  <pre id="token-display"></pre>
+  <button onclick="copyToken()">Copy token</button>
+
   <textarea id="message" rows="4" placeholder="Zadej dotaz…"></textarea><br>
   <input type="file" id="file" accept=".txt,.pdf,.docx"><br>
   <button onclick="ask()">Odeslat</button>
@@ -126,6 +129,10 @@
     let token = localStorage.getItem('token') || '';
     let apiKey = localStorage.getItem('apiKey') || '';
 
+    function copyToken() {
+      if (token) navigator.clipboard.writeText(token);
+    }
+
     function authFetch(url, options = {}) {
       options.headers = options.headers || {};
       if (token) options.headers['Authorization'] = 'Bearer ' + token;
@@ -161,10 +168,11 @@
       document.getElementById('current-model').textContent = name;
     }
 
-    function showInterface() {
+   function showInterface() {
       document.getElementById('login').style.display = 'none';
       document.getElementById('interface').style.display = 'block';
       loadModel();
+      document.getElementById('token-display').textContent = token;
       const select = document.getElementById('model-select');
       if (select) select.addEventListener('change', switchModel);
     }
@@ -198,6 +206,7 @@
         const data = await res.json();
         token = data.token;
         localStorage.setItem('token', token);
+        document.getElementById('token-display').textContent = token;
         document.getElementById('login-status').textContent = '';
         showInterface();
       } else {


### PR DESCRIPTION
## Summary
- add token display and copy button in the web interface
- show token after login and when returning to a logged-in state
- add small helper to copy the token
- document token display and copy feature in README

## Testing
- `pytest`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_b_685e2a4b7ce08322b948686b44847814