### PR TITLE
Print restart reminder after adding user

### DIFF
--- a/tools/create_user.py
+++ b/tools/create_user.py
@@ -38,6 +38,7 @@ def main() -> None:
     users.append({"nick": nick, "password_hash": auth.hash_password(password)})
     save_users(users)
     print(f"User '{nick}' added to {USERS_FILE}")
+    print("Restart the Flask server to load updated users.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- remind administrators to restart Flask after running `create_user.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685e3164d500832280584f5d8dbc0780