### PR TITLE
Improve word matching in RAG

### DIFF
--- a/rag_engine.py
+++ b/rag_engine.py
@@ -125,7 +125,10 @@ def search_knowledge(query, knowledge_chunks, threshold=0.6):
         chunk_lower = _strip_diacritics(chunk.lower())
         ratio = SequenceMatcher(None, clean_query, chunk_lower).ratio()
 
-        if any(word in chunk_lower for word in query_words) or ratio >= threshold:
+        if any(
+            re.search(r"\b" + re.escape(word) + r"\b", chunk_lower)
+            for word in query_words
+        ) or ratio >= threshold:
             matches.append((ratio, chunk[:500]))  # Shorten for the prompt
 
     matches.sort(key=lambda x: x[0], reverse=True)

--- a/tests/test_rag_engine.py
+++ b/tests/test_rag_engine.py
@@ -111,6 +111,12 @@ def test_search_knowledge_diacritics_normalization():
     assert result == ["DJ \u0160muk"]
 
 
+def test_search_knowledge_word_boundary():
+    chunks = ["GR8DJEYM2A", "dj smuk"]
+    result = search_knowledge("dj", chunks)
+    assert result == ["dj smuk"]
+
+
 def test_knowledge_base_env_threshold(monkeypatch, knowledge_dir):
     kb = KnowledgeBase(str(knowledge_dir))
     # Without the environment variable there should be no match


### PR DESCRIPTION
## Summary
- tighten word matching in `rag_engine.search_knowledge`
- add unit test to confirm partial-word matches are ignored

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_685ebdf88b008322b036380264968083