### PR TITLE
Add DJ Šmuk knowledge base test

### DIFF
--- a/tests/test_rag_engine.py
+++ b/tests/test_rag_engine.py
@@ -140,3 +140,19 @@ def test_knowledge_base_multiple_folders(tmp_path):
 
     assert any("hello" in c for c in kb.chunks)
     assert any("world" in c for c in kb.chunks)
+
+
+def test_knowledge_base_dj_smuk_search(tmp_path):
+    """KnowledgeBase can search text with diacritics."""
+    folder = tmp_path / "kb"
+    folder.mkdir()
+    text = (
+        "DJ \u0160muk is a Czech DJ and producer known for high\u2011energy sets that "
+        "make crowds dance. Despite the name similarity to some websites, DJ \u0160muk"
+        " is a person, not an online platform."
+    )
+    (folder / "dj_smuk_info.txt").write_text(text, encoding="utf-8")
+
+    kb = KnowledgeBase(str(folder))
+
+    assert kb.search("DJ \u0160muk") == [text]


### PR DESCRIPTION
## Summary
- extend rag engine tests with a case for diacritics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685f25720e288322b125147f2938ae5b