### PR TITLE
Fix ask_file error on older Flask versions

### DIFF
--- a/main.py
+++ b/main.py
@@ -479,7 +479,14 @@ def ask_file():
                 pass
             return resp
 
-        resp = send_file(out_path, as_attachment=True, download_name=f"odpoved{ext}")
+        try:
+            resp = send_file(
+                out_path, as_attachment=True, download_name=f"odpoved{ext}"
+            )
+        except TypeError:  # Flask < 2.0 uses attachment_filename
+            resp = send_file(
+                out_path, as_attachment=True, attachment_filename=f"odpoved{ext}"
+            )
         resp.headers["X-Answer"] = output
         resp.headers["X-Debug"] = json.dumps(debug_log)
         return resp


### PR DESCRIPTION
## Summary
- ensure `/ask_file` route works with Flask < 2 by falling back to `attachment_filename`

## Testing
- `pytest -q`
- `ruff check main.py`

------
https://chatgpt.com/codex/tasks/task_b_685f8a4307e08322a6a6b6977c0fa5e8