### PR TITLE
Add FAISS-based RAG engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ alias launches the default Gemma 2B model.
 
 Knowledge files are loaded from the `knowledge/` folder at startup. Jarvik uses
 the `KnowledgeBase` class from `rag_engine.py`, which reads all `.txt`, `.pdf`
-and `.docx` files and stores their non-empty contents in memory. PDF and DOCX
-support requires the optional packages `PyPDF2` and `python-docx` listed in
+and `.docx` files, splits them into paragraphs and indexes them with FAISS.
+PDF and DOCX support requires the optional packages `PyPDF2` and `python-docx`
+while vector search relies on `sentence-transformers` and `faiss-cpu` listed in
 `requirements.txt`.
 
 ### Folder layout and per-user data
@@ -57,9 +58,9 @@ Conversation history is stored in `memory/`. The public log lives in
 `knowledge/<nick>` subfolders listed in `users.json` are loaded for that user in
 addition to the public files.
 
-The fuzzy search threshold defaults to `0.6`. You can tweak how loosely queries
-match the knowledge base by setting the `RAG_THRESHOLD` environment variable to a
-floating point value.
+The similarity threshold for vector search defaults to `0.7`. You can tweak how
+strictly queries match the knowledge base by setting the `RAG_THRESHOLD`
+environment variable to a floating point value.
 
 ### Text-only mode
 

--- a/manual
+++ b/manual
@@ -7,7 +7,7 @@ Flask API naslouchá na portu `8010`, který lze změnit proměnnou `FLASK_PORT`
 Pro vzdálenou Ollamu nastavte proměnnou `OLLAMA_URL` (výchozí
 `http://localhost:11434`).
 Citlivost vyhledávání ve znalostech můžete upravit proměnnou `RAG_THRESHOLD`
-(výchozí hodnota je `0.6`).
+(výchozí hodnota je `0.7`).
 
 ## Instalace
 

--- a/rag_engine.py
+++ b/rag_engine.py
@@ -2,24 +2,32 @@ import os
 import glob
 import re
 import unicodedata
-from difflib import SequenceMatcher
+from typing import List
 
-# Flags indicating whether optional dependencies are available
+# Optional dependencies -------------------------------------------------------
 PDF_SUPPORT = False
 DOCX_SUPPORT = False
+VECTOR_SUPPORT = False
+
+try:  # pragma: no cover - environment specific
+    import faiss  # type: ignore
+    from sentence_transformers import SentenceTransformer  # type: ignore
+    VECTOR_SUPPORT = True
+except Exception:  # pragma: no cover - missing packages
+    VECTOR_SUPPORT = False
 
 
 def _check_optional_dependencies() -> None:
     """Set :data:`PDF_SUPPORT` and :data:`DOCX_SUPPORT` globals."""
     global PDF_SUPPORT, DOCX_SUPPORT
     try:  # pragma: no cover - availability is system dependent
-        import PyPDF2  # noqa: F401
+        import PyPDF2  # type: ignore
 
         PDF_SUPPORT = True
     except Exception:
         PDF_SUPPORT = False
     try:  # pragma: no cover - availability is system dependent
-        import docx  # noqa: F401
+        import docx  # type: ignore
 
         DOCX_SUPPORT = True
     except Exception:
@@ -35,24 +43,32 @@ __all__ = [
     "load_knowledge",
     "search_knowledge",
     "KnowledgeBase",
+    "get_relevant_chunks",
     "dependency_status",
+    "_strip_diacritics",
 ]
 
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
 
 def _strip_diacritics(text: str) -> str:
     """Return *text* without any diacritical marks."""
     normalized = unicodedata.normalize("NFD", text)
     return "".join(c for c in normalized if not unicodedata.combining(c))
 
-def load_txt_file(path):
+
+def load_txt_file(path: str) -> str:
     with open(path, "r", encoding="utf-8") as f:
         return f.read()
 
-def load_pdf_file(path):
-    try:
-        import PyPDF2
-    except ImportError:
+
+def load_pdf_file(path: str) -> str:
+    if not PDF_SUPPORT:
         raise ImportError("PyPDF2 is required to load PDF files")
+
+    import PyPDF2  # type: ignore
 
     text = ""
     with open(path, "rb") as f:
@@ -61,18 +77,25 @@ def load_pdf_file(path):
             text += page.extract_text() or ""
     return text
 
-def load_docx_file(path):
-    try:
-        import docx
-    except ImportError:
+
+def load_docx_file(path: str) -> str:
+    if not DOCX_SUPPORT:
         raise ImportError("python-docx is required to load DOCX files")
 
-    doc = docx.Document(path)
-    return "\n".join([p.text for p in doc.paragraphs])
+    import docx  # type: ignore
 
-def _load_folder(folder: str) -> list[str]:
-    """Return a list of non-empty knowledge chunks from *folder*."""
-    chunks: list[str] = []
+    doc = docx.Document(path)
+    return "\n".join(p.text for p in doc.paragraphs)
+
+
+def _split_paragraphs(text: str) -> List[str]:
+    paragraphs = [p.strip() for p in re.split(r"\n{2,}", text) if p.strip()]
+    return paragraphs
+
+
+def _load_folder(folder: str) -> List[str]:
+    """Return a list of non-empty knowledge paragraphs from *folder*."""
+    chunks: List[str] = []
     warned_pdf = False
     warned_docx = False
     for ext in ("*.txt", "*.pdf", "*.docx"):
@@ -94,85 +117,126 @@ def _load_folder(folder: str) -> list[str]:
                     content = load_pdf_file(path)
                 elif ext == "*.docx":
                     content = load_docx_file(path)
-                else:
+                else:  # pragma: no cover - not reachable
                     continue
-                content = content.strip()
-                if content:
-                    chunks.append(content)
+                for para in _split_paragraphs(content):
+                    chunks.append(para)
             except Exception as e:  # pragma: no cover - just log errors
                 print(f"❌ Nelze načíst {path}: {e}")
     return chunks
 
 
-def load_knowledge(folder: str) -> list[str]:
-    """Backward compatible wrapper returning knowledge chunks."""
+def load_knowledge(folder: str) -> List[str]:
+    """Backward compatible helper returning paragraphs from *folder*."""
     return _load_folder(folder)
 
-def search_knowledge(query, knowledge_chunks, threshold=0.6):
-    """Return up to five knowledge chunks relevant to *query*.
 
-    A chunk is included when any word from the cleaned query appears in it or
-    when the similarity ratio computed via :class:`difflib.SequenceMatcher`
-    exceeds the given *threshold*.
-    """
-
-    normalized_query = _strip_diacritics(query.lower())
-    clean_query = re.sub(r"\W+", " ", normalized_query)
-    query_words = [w for w in clean_query.split() if w]
-
-    matches = []
-    for chunk in knowledge_chunks:
-        chunk_lower = _strip_diacritics(chunk.lower())
-        ratio = SequenceMatcher(None, clean_query, chunk_lower).ratio()
-
-        if any(
-            re.search(r"\b" + re.escape(word) + r"\b", chunk_lower)
-            for word in query_words
-        ) or ratio >= threshold:
-            matches.append((ratio, chunk[:500]))  # Shorten for the prompt
-
-    matches.sort(key=lambda x: x[0], reverse=True)
-    return [m[1] for m in matches[:5]]
-
+# ---------------------------------------------------------------------------
+# Vector search implementation
+# ---------------------------------------------------------------------------
 
 class KnowledgeBase:
-    """Manage loading and searching local knowledge files from one or more folders."""
+    """Manage loading and searching local knowledge files using FAISS."""
 
-    def __init__(self, folder: str | list[str]):
-        if isinstance(folder, str):
-            self.folders = [folder]
-        else:
-            self.folders = list(folder)
-        self.chunks: list[str] = []
+    def __init__(self, folder: str | List[str], model_name: str | None = None):
+        if not VECTOR_SUPPORT:
+            raise ImportError("sentence-transformers and faiss are required")
+        self.folders = [folder] if isinstance(folder, str) else list(folder)
+        self.model_name = model_name or os.getenv(
+            "RAG_MODEL", "paraphrase-multilingual-MiniLM-L12-v2"
+        )
+        self.model = SentenceTransformer(self.model_name)
+        self.chunks: List[str] = []
+        self.index: faiss.Index | None = None
         self.reload()
 
+    # ------------------------------------------------------------------
     def reload(self) -> None:
-        """(Re)load all supported files from :attr:`folders`."""
-        chunks: list[str] = []
+        """(Re)load knowledge files and rebuild the vector index."""
+        chunks: List[str] = []
         for folder in self.folders:
             chunks.extend(_load_folder(folder))
         self.chunks = chunks
+        if not chunks:
+            self.index = None
+            return
+        embeddings = self.model.encode(
+            chunks, show_progress_bar=False, normalize_embeddings=True
+        )
+        dim = embeddings.shape[1]
+        self.index = faiss.IndexFlatIP(dim)
+        self.index.add(embeddings.astype("float32"))
 
-    def search(self, query: str, threshold: float | None = None) -> list[str]:
-        """Search loaded chunks for *query* using :func:`search_knowledge`.
-
-        When ``threshold`` is ``None`` the value is read from the
-        ``RAG_THRESHOLD`` environment variable. If that variable is missing or
-        invalid the default ``0.6`` is used.
-        """
-
+    # ------------------------------------------------------------------
+    def search(
+        self,
+        query: str,
+        threshold: float | None = None,
+        top_k: int = 5,
+    ) -> List[str]:
+        """Return up to *top_k* relevant paragraphs for *query*."""
+        if self.index is None or not self.chunks:
+            return []
         if threshold is None:
             env = os.getenv("RAG_THRESHOLD")
             try:
-                threshold = float(env) if env is not None else 0.6
+                threshold = float(env) if env is not None else 0.7
             except ValueError:  # pragma: no cover - environment may be invalid
-                threshold = 0.6
+                threshold = 0.7
+        query_vec = self.model.encode(
+            [query], show_progress_bar=False, normalize_embeddings=True
+        )
+        scores, idx = self.index.search(query_vec.astype("float32"), top_k)
+        results = []
+        for score, i in zip(scores[0], idx[0]):
+            if score >= threshold:
+                results.append(self.chunks[i])
+        return results
 
-        return search_knowledge(query, self.chunks, threshold)
+
+# ---------------------------------------------------------------------------
+# Convenience API
+# ---------------------------------------------------------------------------
+
+_DEFAULT_FOLDER = os.path.join(os.path.dirname(__file__), "knowledge")
+_default_kb: KnowledgeBase | None = None
+
+
+def _get_default_kb() -> KnowledgeBase:
+    global _default_kb
+    if _default_kb is None:
+        _default_kb = KnowledgeBase(_DEFAULT_FOLDER)
+    return _default_kb
+
+
+def search_knowledge(query: str, knowledge_chunks: List[str], threshold: float = 0.7) -> List[str]:
+    """Search a list of paragraphs without creating a persistent instance."""
+    if not VECTOR_SUPPORT:
+        raise ImportError("sentence-transformers and faiss are required")
+    model = SentenceTransformer(os.getenv("RAG_MODEL", "paraphrase-multilingual-MiniLM-L12-v2"))
+    embeddings = model.encode(knowledge_chunks, show_progress_bar=False, normalize_embeddings=True)
+    index = faiss.IndexFlatIP(embeddings.shape[1])
+    index.add(embeddings.astype("float32"))
+    q_vec = model.encode([query], show_progress_bar=False, normalize_embeddings=True)
+    scores, idx = index.search(q_vec.astype("float32"), min(5, len(knowledge_chunks)))
+    results = []
+    for score, i in zip(scores[0], idx[0]):
+        if score >= threshold:
+            results.append(knowledge_chunks[i])
+    return results
+
+
+def get_relevant_chunks(query: str, threshold: float = 0.7, top_k: int = 5) -> List[str]:
+    """Search the default knowledge base for *query*."""
+    kb = _get_default_kb()
+    return kb.search(query, threshold=threshold, top_k=top_k)
 
 
 def dependency_status() -> dict[str, bool]:
     """Return which optional dependencies are available."""
 
-    return {"pdf": PDF_SUPPORT, "docx": DOCX_SUPPORT}
-
+    return {
+        "pdf": PDF_SUPPORT,
+        "docx": DOCX_SUPPORT,
+        "vector": VECTOR_SUPPORT,
+    }

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,6 @@ fpdf
 filelock
 duckduckgo-search
 beautifulsoup4
+sentence-transformers
+faiss-cpu
 


### PR DESCRIPTION
## Summary
- implement new FAISS powered `KnowledgeBase`
- add helper `get_relevant_chunks`
- install `sentence-transformers` and `faiss-cpu`
- document new search method and threshold

## Testing
- `ruff check .`
- `pytest -q` *(fails: ImportError: sentence-transformers and faiss are required)*

------
https://chatgpt.com/codex/tasks/task_b_685f8c8f213483229c4976d2713159c0