### PR TITLE
Fix duckduckgo-search version

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ bash install_jarvik.sh
 ```
 
 After running the installer, ensure the package `duckduckgo-search` is
-available in version 0.8 or newer. If needed, activate the virtual environment
+available in version 8.0.4 or newer. If needed, activate the virtual environment
 and run:
 
 ```bash
-pip install -U duckduckgo-search==0.8
+pip install -U duckduckgo-search==8.0.4
 ```
 
 Make sure the commands `ollama`, `curl`, `lsof` and either `ss` (from

--- a/manual
+++ b/manual
@@ -21,10 +21,10 @@ Citlivost vyhledávání ve znalostech můžete upravit proměnnou `RAG_THRESHOL
    ```
 
 2. Po skončení instalace zkontrolujte, že je k dispozici balíček `duckduckgo-search`
-   ve verzi 0.8 nebo novější. Pokud chybí, doinstalujte jej v aktivovaném
+   ve verzi 8.0.4 nebo novější. Pokud chybí, doinstalujte jej v aktivovaném
    virtuálním prostředí příkazem:
    ```bash
-   pip install -U duckduckgo-search==0.8
+    pip install -U duckduckgo-search==8.0.4
    ```
 
 3. Po dokončení instalace načtěte aliasy usnadňující práci se skripty:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pdfplumber
 python-docx
 fpdf
 filelock
-duckduckgo-search==0.8
+duckduckgo-search==8.0.4
 beautifulsoup4
 sentence-transformers
 faiss-cpu


### PR DESCRIPTION
## Summary
- update `duckduckgo-search` requirement to 8.0.4
- document the new version in README and manual

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685fc894a0e8832280a0ca127e095102