### PR TITLE
Update ruff CLI usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,8 +393,10 @@ Unit tests live in the `tests/` directory. Execute them with:
 
 ```bash
 pytest
-ruff .
+ruff check .
 ```
+
+Run `ruff --fix` to automatically resolve simple issues.
 
 ## License
 


### PR DESCRIPTION
## Summary
- replace deprecated `ruff .` command in README
- note about using `ruff --fix` for simple fixes

## Testing
- `pytest -q`
- `ruff check .` *(fails: E401, E741)*

------
https://chatgpt.com/codex/tasks/task_b_685fd16c27488322b6350dc26fa43877