### PR TITLE
Update duckduckgo-search requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ bash install_jarvik.sh
 ```
 
 After running the installer, ensure the package `duckduckgo-search` is
-available in version 8.0.4 or newer. If needed, activate the virtual environment
+available in version 8.0 or newer. If needed, activate the virtual environment
 and run:
 
 ```bash
-pip install -U duckduckgo-search==8.0.4
+pip install -U duckduckgo-search>=8.0
 ```
 
 Make sure the commands `ollama`, `curl`, `lsof` and either `ss` (from

--- a/manual
+++ b/manual
@@ -21,10 +21,10 @@ Citlivost vyhledávání ve znalostech můžete upravit proměnnou `RAG_THRESHOL
    ```
 
 2. Po skončení instalace zkontrolujte, že je k dispozici balíček `duckduckgo-search`
-   ve verzi 8.0.4 nebo novější. Pokud chybí, doinstalujte jej v aktivovaném
-   virtuálním prostředí příkazem:
+    ve verzi 8.0 nebo novější. Pokud chybí, doinstalujte jej v aktivovaném
+    virtuálním prostředí příkazem:
    ```bash
-    pip install -U duckduckgo-search==8.0.4
+     pip install -U duckduckgo-search>=8.0
    ```
 
 3. Po dokončení instalace načtěte aliasy usnadňující práci se skripty:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pdfplumber
 python-docx
 fpdf
 filelock
-duckduckgo-search==8.0.4
+duckduckgo-search>=8.0
 beautifulsoup4
 sentence-transformers
 faiss-cpu


### PR DESCRIPTION
## Summary
- loosen duckduckgo-search requirement to support newer versions
- update README and manual installation instructions

## Testing
- `pytest -q`
- `python -m py_compile tools/web_search.py`


------
https://chatgpt.com/codex/tasks/task_b_685fd15da6c483228622949f66f7ebe3