### PR TITLE
Add helper for local LLM

### DIFF
--- a/main.py
+++ b/main.py
@@ -38,6 +38,23 @@ except ValueError:
 # Set base directory relative to this file
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
+# ---------------------------------------------------------------------------
+# Helper to call the local LLM via Ollama
+# ---------------------------------------------------------------------------
+import requests
+
+
+def generate_response_with_context(context: str, prompt: str) -> str:
+    """Return the model response for *prompt* with prepended *context*."""
+    full_prompt = f"{context}\n\n{prompt}"
+    res = requests.post(
+        f"{OLLAMA_URL}/api/generate",
+        json={"model": MODEL_NAME, "prompt": full_prompt, "stream": False},
+        timeout=10,
+    )
+    data = res.json()
+    return data.get("response", "")
+
 # --- Authentication setup -------------------------------------------------
 USERS_FILE = os.path.join(BASE_DIR, "users.json")
 users = load_users(USERS_FILE)


### PR DESCRIPTION
## Summary
- add a `generate_response_with_context` helper in `main.py`
- call Ollama's `/api/generate` with a timeout

## Testing
- `pytest`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_b_68613c9c8a608322ad85bde74df938c8