### PR TITLE
Update monitor to use current Ollama model

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,8 +288,9 @@ To continuously watch Jarvik's state and recent logs, run:
 bash monitor.sh
 ```
 
-The script refreshes every two seconds and shows the last lines from
-`flask.log`, `<model>.log` and `ollama.log` produced by `start_jarvik.sh`.
+The script refreshes every two seconds, detects whichever model Ollama
+is currently serving and shows the last lines from `flask.log`,
+`<model>.log` and `ollama.log` produced by `start_jarvik.sh`.
 
 ## Automatic Restart
 

--- a/monitor.sh
+++ b/monitor.sh
@@ -5,11 +5,21 @@
 DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$DIR" || exit
 
-# Default model name if not provided
-MODEL_NAME=${MODEL_NAME:-"gemma:2b"}
-MODEL_LOG="${MODEL_NAME}.log"
+get_active_model() {
+  if command -v jq >/dev/null 2>&1; then
+    curl -s http://localhost:11434/api/tags | jq -r '.[0].name'
+  else
+    curl -s http://localhost:11434/api/tags |\
+      grep -o '"name":"[^"]*"' | head -n 1 | sed -e 's/"name":"//' -e 's/"$//'
+  fi
+}
+
+MODEL="$(get_active_model)"
+MODEL_LOG="${MODEL}.log"
 
 while true; do
+  MODEL="$(get_active_model)"
+  MODEL_LOG="${MODEL}.log"
   clear
   echo "===== Stav Jarvika ====="
   bash status.sh


### PR DESCRIPTION
## Summary
- detect the active model from Ollama inside `monitor.sh`
- fall back to `grep`/`sed` when `jq` isn't available
- mention automatic detection in the monitoring section of the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6861ac7ecd548322b9ad65286768e9df