### PR TITLE
Use colon-safe model log name

### DIFF
--- a/monitor.sh
+++ b/monitor.sh
@@ -15,11 +15,11 @@ get_active_model() {
 }
 
 MODEL="$(get_active_model)"
-MODEL_LOG="${MODEL}.log"
+MODEL_LOG="${MODEL//:/_}.log"
 
 while true; do
   MODEL="$(get_active_model)"
-  MODEL_LOG="${MODEL}.log"
+  MODEL_LOG="${MODEL//:/_}.log"
   clear
   echo "===== Stav Jarvika ====="
   bash status.sh

--- a/start_jarvik.sh
+++ b/start_jarvik.sh
@@ -11,7 +11,7 @@ cd "$(dirname "$0")" || exit
 # Model name can be overridden with the MODEL_NAME environment variable
 MODEL_NAME=${MODEL_NAME:-"gemma:2b"}
 # Log file for the model output
-MODEL_LOG="${MODEL_NAME}.log"
+MODEL_LOG="${MODEL_NAME//:/_}.log"
 # Optional LOCAL_MODEL_FILE can specify a .gguf file to register as this model
 
 # Aktivovat venv, pokud ještě není aktivní

--- a/start_model.sh
+++ b/start_model.sh
@@ -7,7 +7,7 @@ cd "$(dirname "$0")" || exit
 
 # Default model name can be overridden via MODEL_NAME
 MODEL_NAME=${MODEL_NAME:-"gemma:2b"}
-MODEL_LOG="${MODEL_NAME}.log"
+MODEL_LOG="${MODEL_NAME//:/_}.log"
 # Optional local .gguf file to register as MODEL_NAME when not present
 # Set LOCAL_MODEL_FILE to the path of your .gguf file
 

--- a/watchdog.sh
+++ b/watchdog.sh
@@ -2,6 +2,7 @@
 
 FLASK_PORT=${FLASK_PORT:-8010}
 MODEL_NAME=${MODEL_NAME:-"gemma:2b"}
+MODEL_LOG="${MODEL_NAME//:/_}.log"
 
 GREEN="\033[1;32m"
 RED="\033[1;31m"
@@ -47,7 +48,7 @@ check_ollama() {
 check_model() {
   if ! curl -s http://localhost:11434/api/tags | grep -q "$MODEL_NAME"; then
     echo -e "${RED}❌ Model $MODEL_NAME neběží. Restartuji...${NC}"
-    nohup ollama run "$MODEL_NAME" > "${MODEL_NAME}.log" 2>&1 &
+    nohup ollama run "$MODEL_NAME" > "$MODEL_LOG" 2>&1 &
   fi
 }
 


### PR DESCRIPTION
## Summary
- escape colons when constructing MODEL_LOG in start scripts
- update watchdog and monitor scripts to reference the new log variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6861b2c983cc8322869e4b32eac28184