### PR TITLE
Switch knowledge base to Markdown-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,9 @@ This will append alias commands such as `jarvik-start`, `jarvik-status`,
 alias launches the default Gemma 2B model.
 
 Knowledge files are loaded from the `knowledge/` folder at startup. Jarvik uses
-the `KnowledgeBase` class from `rag_engine.py`, which reads all `.txt`, `.pdf`
-and `.docx` files, splits them into paragraphs and indexes them with FAISS.
-PDF and DOCX support requires the optional packages `PyPDF2` and `python-docx`
-while vector search relies on `sentence-transformers` and `faiss-cpu` listed in
-`requirements.txt`.
+the `KnowledgeBase` class from `rag_engine.py`, which reads all `.md` files,
+splits them into paragraphs and indexes them with FAISS. Vector search relies
+on `sentence-transformers` and `faiss-cpu` listed in `requirements.txt`.
 
 ### Folder layout and per-user data
 
@@ -73,14 +71,13 @@ environment variable to a floating point value.
 
 ### Text-only mode
 
-If you only work with plain text files you can simplify Jarvik:
+Jarvik now works exclusively with Markdown files.
 
-1. Edit `static/index.html` so the file input uses `accept=".txt"`.
-2. Remove the `.pdf` and `.docx` branches from the `/ask_file` handler in
-   `main.py`.
+1. Ensure `static/index.html` uses `accept=".md"`.
+2. The `/ask_file` handler in `main.py` loads uploaded Markdown with
+   `load_txt_file` and saves replies as `.md` files.
 
-After these changes Jarvik will only process TXT files and you may remove the
-`PyPDF2` and `python-docx` packages from your environment.
+PDF and DOCX dependencies are no longer required.
 
 ## Starting Jarvik
 

--- a/main.py
+++ b/main.py
@@ -3,8 +3,6 @@ from rag_engine import (
     KnowledgeBase,
     dependency_status,
     load_txt_file,
-    load_pdf_file,
-    load_docx_file,
     _strip_diacritics,
 )
 import difflib
@@ -112,11 +110,6 @@ PUBLIC_KNOWLEDGE_FOLDER = os.path.join(BASE_DIR, "knowledge")
 knowledge = KnowledgeBase(PUBLIC_KNOWLEDGE_FOLDER)
 user_knowledge: dict[str, KnowledgeBase] = {}
 print("✅ Znalosti načteny.")
-deps = dependency_status()
-if not deps["pdf"]:
-    print("⚠️  PDF soubory se nenačtou – nainstalujte balíček PyPDF2")
-if not deps["docx"]:
-    print("⚠️  DOCX soubory se nenačtou – nainstalujte balíček python-docx")
 
 
 def get_knowledge_base(user: User | None) -> KnowledgeBase:
@@ -418,14 +411,11 @@ def ask_file():
             uploaded.save(tmp.name)
             tmp_path = tmp.name
         try:
-            if ext == ".txt":
+            if ext == ".md":
                 file_text = load_txt_file(tmp_path)
-            elif ext == ".pdf":
-                file_text = load_pdf_file(tmp_path)
-            elif ext == ".docx":
-                file_text = load_docx_file(tmp_path)
             else:
                 debug_log.append(f"Nepodporovaný typ souboru: {uploaded.filename}")
+                ext = None
         except Exception as e:
             debug_log.append(f"Chyba při čtení souboru: {e}")
         finally:
@@ -491,27 +481,12 @@ def ask_file():
     target_folder = user.nick if user else DEFAULT_MEMORY_FOLDER
     append_to_memory(message, output, folder=target_folder)
 
-    if ext in {".txt", ".pdf", ".docx"}:
+    if ext == ".md":
         with tempfile.NamedTemporaryFile(delete=False, suffix=ext) as tmp_out:
             out_path = tmp_out.name
         try:
-            if ext == ".txt":
-                with open(out_path, "w", encoding="utf-8") as f:
-                    f.write(output)
-            elif ext == ".docx":
-                from docx import Document
-                doc = Document()
-                doc.add_paragraph(output)
-                doc.save(out_path)
-            elif ext == ".pdf":
-                from fpdf import FPDF
-                pdf = FPDF()
-                pdf.add_page()
-                pdf.set_auto_page_break(auto=True, margin=15)
-                pdf.set_font("Arial", size=12)
-                for line in output.split("\n"):
-                    pdf.cell(0, 10, txt=line, ln=1)
-                pdf.output(out_path)
+            with open(out_path, "w", encoding="utf-8") as f:
+                f.write(output)
         except Exception as e:
             debug_log.append(f"Chyba při vytváření souboru: {e}")
             os.unlink(out_path)
@@ -589,11 +564,6 @@ def knowledge_reload():
     folders = [user.nick] + user.memory_folders if user else None
     reload_memory(folders)
     print("✅ Znalosti načteny.")
-    deps = dependency_status()
-    if not deps["pdf"]:
-        print("⚠️  PDF soubory se nenačtou – nainstalujte balíček PyPDF2")
-    if not deps["docx"]:
-        print("⚠️  DOCX soubory se nenačtou – nainstalujte balíček python-docx")
     return jsonify({"status": "reloaded", "chunks": len(kb.chunks)})
 
 

--- a/rag_engine.py
+++ b/rag_engine.py
@@ -5,9 +5,7 @@ import unicodedata
 import difflib
 from typing import List
 
-# Optional dependencies -------------------------------------------------------
-PDF_SUPPORT = False
-DOCX_SUPPORT = False
+# Optional dependency --------------------------------------------------------
 VECTOR_SUPPORT = False
 
 try:  # pragma: no cover - environment specific
@@ -17,30 +15,8 @@ try:  # pragma: no cover - environment specific
 except Exception:  # pragma: no cover - missing packages
     VECTOR_SUPPORT = False
 
-
-def _check_optional_dependencies() -> None:
-    """Set :data:`PDF_SUPPORT` and :data:`DOCX_SUPPORT` globals."""
-    global PDF_SUPPORT, DOCX_SUPPORT
-    try:  # pragma: no cover - availability is system dependent
-        import PyPDF2  # type: ignore  # noqa: F401
-
-        PDF_SUPPORT = True
-    except Exception:
-        PDF_SUPPORT = False
-    try:  # pragma: no cover - availability is system dependent
-        import docx  # type: ignore  # noqa: F401
-
-        DOCX_SUPPORT = True
-    except Exception:
-        DOCX_SUPPORT = False
-
-
-_check_optional_dependencies()
-
 __all__ = [
     "load_txt_file",
-    "load_pdf_file",
-    "load_docx_file",
     "load_knowledge",
     "search_knowledge",
     "KnowledgeBase",
@@ -89,28 +65,7 @@ def load_txt_file(path: str) -> str:
         return f.read()
 
 
-def load_pdf_file(path: str) -> str:
-    if not PDF_SUPPORT:
-        raise ImportError("PyPDF2 is required to load PDF files")
 
-    import PyPDF2  # type: ignore
-
-    text = ""
-    with open(path, "rb") as f:
-        reader = PyPDF2.PdfReader(f)
-        for page in reader.pages:
-            text += page.extract_text() or ""
-    return text
-
-
-def load_docx_file(path: str) -> str:
-    if not DOCX_SUPPORT:
-        raise ImportError("python-docx is required to load DOCX files")
-
-    import docx  # type: ignore
-
-    doc = docx.Document(path)
-    return "\n".join(p.text for p in doc.paragraphs)
 
 
 def _split_paragraphs(text: str) -> List[str]:
@@ -121,33 +76,13 @@ def _split_paragraphs(text: str) -> List[str]:
 def _load_folder(folder: str) -> List[str]:
     """Return a list of non-empty knowledge paragraphs from *folder*."""
     chunks: List[str] = []
-    warned_pdf = False
-    warned_docx = False
-    for ext in ("*.txt", "*.pdf", "*.docx"):
-        if ext == "*.pdf" and not PDF_SUPPORT:
-            if not warned_pdf:
-                print("⚠️  PDF support disabled – install PyPDF2 to enable")
-                warned_pdf = True
-            continue
-        if ext == "*.docx" and not DOCX_SUPPORT:
-            if not warned_docx:
-                print("⚠️  DOCX support disabled – install python-docx to enable")
-                warned_docx = True
-            continue
-        for path in glob.glob(os.path.join(folder, ext)):
-            try:
-                if ext == "*.txt":
-                    content = load_txt_file(path)
-                elif ext == "*.pdf":
-                    content = load_pdf_file(path)
-                elif ext == "*.docx":
-                    content = load_docx_file(path)
-                else:  # pragma: no cover - not reachable
-                    continue
-                for para in _split_paragraphs(content):
-                    chunks.append(para)
-            except Exception as e:  # pragma: no cover - just log errors
-                print(f"❌ Nelze načíst {path}: {e}")
+    for path in glob.glob(os.path.join(folder, "*.md")):
+        try:
+            content = load_txt_file(path)
+            for para in _split_paragraphs(content):
+                chunks.append(para)
+        except Exception as e:  # pragma: no cover - just log errors
+            print(f"❌ Nelze načíst {path}: {e}")
     return chunks
 
 
@@ -293,8 +228,4 @@ def get_relevant_chunks(query: str, threshold: float = 0.7, top_k: int = 5) -> L
 def dependency_status() -> dict[str, bool]:
     """Return which optional dependencies are available."""
 
-    return {
-        "pdf": PDF_SUPPORT,
-        "docx": DOCX_SUPPORT,
-        "vector": VECTOR_SUPPORT,
-    }
+    return {"vector": VECTOR_SUPPORT}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,5 @@
 flask
 requests
-# Optional extras for PDF/DOCX knowledge base support
-PyPDF2
-pdfplumber
-python-docx
-fpdf
 filelock
 duckduckgo-search>=8.0
 beautifulsoup4

--- a/static/index.html
+++ b/static/index.html
@@ -113,7 +113,7 @@
   <p id="intro">Napiš dotaz nebo přilož soubor a klikni na <strong>Odeslat</strong>.</p>
 
   <textarea id="message" rows="4" placeholder="Zadej dotaz…"></textarea><br>
-  <input type="file" id="file" accept=".txt,.pdf,.docx"><br>
+  <input type="file" id="file" accept=".md"><br>
   <button onclick="ask()">Odeslat</button>
   <pre id="activity"></pre>
 

--- a/tests/test_rag_engine.py
+++ b/tests/test_rag_engine.py
@@ -8,32 +8,11 @@ from rag_engine import KnowledgeBase, load_knowledge, search_knowledge
 
 @pytest.fixture
 def knowledge_dir(tmp_path):
-    """Create a temporary knowledge base with TXT, PDF and DOCX files."""
+    """Create a temporary knowledge base with a Markdown file."""
     folder = tmp_path / "kb"
     folder.mkdir()
 
-    # Always create a TXT file
-    (folder / "info.txt").write_text("TXT knowledge", encoding="utf-8")
-
-    # Create a PDF file when the required packages are available
-    try:
-        from fpdf import FPDF
-        pdf = FPDF()
-        pdf.add_page()
-        pdf.set_font("Arial", size=12)
-        pdf.cell(0, 10, "PDF knowledge")
-        pdf.output(str(folder / "info.pdf"))
-    except Exception:
-        pass
-
-    # Create a DOCX file when the required package is available
-    try:
-        from docx import Document
-        doc = Document()
-        doc.add_paragraph("DOCX knowledge")
-        doc.save(str(folder / "info.docx"))
-    except Exception:
-        pass
+    (folder / "info.md").write_text("MD knowledge", encoding="utf-8")
 
     return folder
 
@@ -66,31 +45,14 @@ def test_search_knowledge_punctuation_removed():
 def test_load_knowledge(knowledge_dir):
     chunks = load_knowledge(knowledge_dir)
 
-    assert "TXT knowledge" in chunks
-
-    if any(f.suffix == ".pdf" for f in knowledge_dir.iterdir()):
-        assert any("PDF knowledge" in c for c in chunks)
-
-    if any(f.suffix == ".docx" for f in knowledge_dir.iterdir()):
-        assert any("DOCX knowledge" in c for c in chunks)
-
-
-def test_load_knowledge_all_formats(knowledge_dir):
-    pytest.importorskip("PyPDF2")
-    pytest.importorskip("fpdf")
-    pytest.importorskip("docx")
-
-    chunks = load_knowledge(knowledge_dir)
-
-    assert any("PDF knowledge" in c for c in chunks)
-    assert any("DOCX knowledge" in c for c in chunks)
+    assert "MD knowledge" in chunks
 
 
 def test_knowledge_base_reload(knowledge_dir):
     kb = KnowledgeBase(str(knowledge_dir))
-    assert any("TXT knowledge" in c for c in kb.chunks)
+    assert any("MD knowledge" in c for c in kb.chunks)
 
-    extra = knowledge_dir / "extra.txt"
+    extra = knowledge_dir / "extra.md"
     extra.write_text("Extra", encoding="utf-8")
     kb.reload()
     assert any("Extra" in c for c in kb.chunks)
@@ -133,8 +95,8 @@ def test_knowledge_base_multiple_folders(tmp_path):
     folder2 = tmp_path / "kb2"
     folder1.mkdir()
     folder2.mkdir()
-    (folder1 / "a.txt").write_text("hello", encoding="utf-8")
-    (folder2 / "b.txt").write_text("world", encoding="utf-8")
+    (folder1 / "a.md").write_text("hello", encoding="utf-8")
+    (folder2 / "b.md").write_text("world", encoding="utf-8")
 
     kb = KnowledgeBase([str(folder1), str(folder2)])
 
@@ -151,7 +113,7 @@ def test_knowledge_base_dj_smuk_search(tmp_path):
         "make crowds dance. Despite the name similarity to some websites, DJ \u0160muk"
         " is a person, not an online platform."
     )
-    (folder / "dj_smuk_info.txt").write_text(text, encoding="utf-8")
+    (folder / "dj_smuk_info.md").write_text(text, encoding="utf-8")
 
     kb = KnowledgeBase(str(folder))
 


### PR DESCRIPTION
## Summary
- limit uploads in the web UI to `.md`
- drop PDF/DOCX support from rag engine and Flask app
- process only Markdown files in `/ask_file`
- adjust optional dependency checks
- update tests and docs for Markdown-only mode
- remove PDF/DOCX packages from requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6861c5472d588322beb42b6f2d0c81ef