### PR TITLE
Update text-only mode docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,10 @@ environment variable to a floating point value.
 
 ### Text-only mode
 
-Jarvik now works exclusively with Markdown files.
-
-1. Ensure `static/index.html` uses `accept=".md"`.
-2. The `/ask_file` handler in `main.py` loads uploaded Markdown with
-   `load_txt_file` and saves replies as `.md` files.
-
-PDF and DOCX dependencies are no longer required.
+Jarvik processes Markdown files by default. The form in
+`static/index.html` accepts only `.md` uploads and the `/ask_file`
+endpoint loads them with `load_txt_file`, storing all replies as Markdown
+documents. Support for PDF and DOCX files has been dropped.
 
 ## Starting Jarvik
 


### PR DESCRIPTION
## Summary
- update README: Jarvik now loads Markdown files by default and dropped PDF/DOCX

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6861cb3277488322ab41e1c6a57a3c9b