### PR TITLE
Add Ruff dev requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,14 @@ logging in.
 
 ## Running Tests
 
-Unit tests live in the `tests/` directory. Execute them with:
+Unit tests live in the `tests/` directory. Install the development
+dependencies first and then execute the tests and style checks:
+
+```bash
+pip install -r dev-requirements.txt
+```
+
+Run the test suite and Ruff with:
 
 ```bash
 pytest

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,2 @@
+ruff
+pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.ruff]
+src = ["."]


### PR DESCRIPTION
## Summary
- add `pyproject.toml` with a basic Ruff section so ruff finds project modules
- list Ruff and pytest in new `dev-requirements.txt`
- document installing dev dependencies in the README

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68625bef16f48322a57c9284522496e3