### PR TITLE
Improve start_flask script

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ When the model is already running you can launch just the Flask API using the
 new helper script or manually:
 
 ```bash
+# automatically stops any previous Flask instance
 bash start_flask.sh
 # or manually
 source venv/bin/activate && python main.py

--- a/manual
+++ b/manual
@@ -154,6 +154,7 @@ Pokud už máte spuštěný model a potřebujete jen Flask server, spusťte nov�
 skript nebo příkaz ručně:
 
 ```bash
+# Skript automaticky ukončí předchozí Flask
 bash start_flask.sh
 # nebo ručně
 source venv/bin/activate && python main.py

--- a/start_flask.sh
+++ b/start_flask.sh
@@ -2,6 +2,21 @@
 
 echo "🚀 Spouštím Flask server Jarvik..."
 
+# Kill any previous Flask instance
+echo "🛑 Zastavuji staré instance Flasku..."
+is_windows() {
+  case "$(uname -s)" in
+    CYGWIN*|MINGW*|MSYS*) return 0 ;;
+  esac
+  [ "$OS" = "Windows_NT" ]
+}
+
+if is_windows && command -v powershell.exe >/dev/null 2>&1; then
+  powershell.exe -Command "Get-Process python -ErrorAction SilentlyContinue | Where-Object { \$_.Path -like '*main.py' } | Stop-Process -Force"
+else
+  pkill -f 'python.*main.py' 2>/dev/null || true
+fi
+
 # Kontrola existence a aktivace venv
 if [ -f "venv/bin/activate" ]; then
   source venv/bin/activate


### PR DESCRIPTION
## Summary
- stop any running Flask instances before starting a new one
- mention the auto-stop behavior in documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68626fe8c3c08322bcb3999b196dcaaf