### PR TITLE
Fix knowledge upload behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ listed in `requirements.txt`. Convert existing PDFs or DOCX documents using
 and `python-docx` for PDF and DOCX conversion, so install them manually if
 needed.
 
+Files uploaded via `/knowledge/upload` are automatically converted to text. Provide a `description` to store a short summary in memory.
 ### Folder layout and per-user data
 
 Conversation history is stored in `memory/`. The public log lives in
@@ -342,6 +343,7 @@ Jarvik exposes a few HTTP endpoints on the configured Flask port
   base files. When ``threshold`` is omitted the server falls back to the value
   of ``RAG_THRESHOLD`` or ``0.6``.
 * `POST /knowledge/reload` – reload the knowledge base and return the number of loaded chunks. This uses the `KnowledgeBase` class to re-read the `knowledge/` directory.
+* `POST /knowledge/upload` – upload a file. Optional fields `private` and `description` mark the file as user-only and store the description in memory.
 * `GET /model` – return the currently running model name.
 
 * `POST /model` – switch models by posting `{ "model": "name" }`.

--- a/main.py
+++ b/main.py
@@ -667,6 +667,8 @@ def knowledge_upload():
 
     kb = get_knowledge_base(user)
     kb.reload()
+    if not private:
+        knowledge.reload()
 
     folder = user.nick if user else DEFAULT_MEMORY_FOLDER
     msg = (

--- a/manual
+++ b/manual
@@ -8,6 +8,7 @@ Pro vzdálenou Ollamu nastavte proměnnou `OLLAMA_URL` (výchozí
 `http://localhost:11434`).
 Citlivost vyhledávání ve znalostech můžete upravit proměnnou `RAG_THRESHOLD`
 (výchozí hodnota je `0.7`).
+Znalostní soubory lze nahrávat v rozhraní pomocí tlačítka "Nahrát". Ke každému souboru můžete uvést popis, který se uloží do paměti.
 
 ## Instalace
 


### PR DESCRIPTION
## Summary
- ensure public uploads refresh the global knowledge base
- document description field and knowledge upload endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6862a592d2a88322803cd4c114d6e206