### PR TITLE
Switch default Flask port to 8000

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -3,7 +3,7 @@
 Tento krátký manuál popisuje základní kroky pro instalaci a spuštění Jarvika na lokálním stroji.
 
 Ve výchozím nastavení je použit model `openchat`. Model lze kdykoli změnit ve webovém rozhraní nebo voláním endpointu `/model`. V příkladech je předpokládán OpenChat, jiný model zvolíte nastavením proměnné `MODEL_NAME` při spouštění skriptů.
-Flask API naslouchá na portu `8010`, který lze změnit proměnnou `FLASK_PORT`.
+Flask API naslouchá na portu `8000`, který lze změnit proměnnou `FLASK_PORT`.
 Pro vzdálenou Ollamu nastavte proměnnou `OLLAMA_URL` (výchozí
 `http://localhost:11434`).
 Citlivost vyhledávání ve znalostech můžete upravit proměnnou `RAG_THRESHOLD`
@@ -45,7 +45,7 @@ bash start_openchat.sh
 jarvik-start
 ```
 Skript aktivuje virtuální prostředí, spustí Ollamu, zvolený model (výchozí
-OpenChat) a nakonec Flask server na portu 8010 (lze změnit proměnnou
+OpenChat) a nakonec Flask server na portu 8000 (lze změnit proměnnou
 `FLASK_PORT`). Pokud model chybí, stáhne se automaticky. Pro jiný model
 nastavte proměnnou `MODEL_NAME` při spuštění – všechny dodané skripty ji nyní
 plně respektují. Například:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ models at any time via the web interface or by calling the `/model` endpoint.
 Alternatively set the `MODEL_NAME` environment variable when starting a script
 to run a different model. Jarvik keeps the entire conversation history by
 default.
-The Flask API listens on port `8010` by default, but you can override this using
+The Flask API listens on port `8000` by default, but you can override this using
 the `FLASK_PORT` environment variable. The `FLASK_HOST` variable controls the
 address the server binds to and defaults to `0.0.0.0`. Set `FLASK_HOST=127.0.0.1`
 if you want to restrict connections to the local machine. Setting `FLASK_HOST` to
@@ -321,7 +321,7 @@ so any uncommitted changes will be lost.
 ## API Usage
 
 Jarvik exposes a few HTTP endpoints on the configured Flask port
-(default `8010`) that can be consumed by external applications such as ChatGPT:
+(default `8000`) that can be consumed by external applications such as ChatGPT:
 
 * `POST /ask` – ask Jarvik a question. The conversation is stored in memory.
 * `POST /memory/add` – manually append a `{ "user": "...", "jarvik": "..." }`
@@ -436,13 +436,13 @@ helper reads the target URL from the `JARVIK_URL` environment variable or from a
 `devlab_config.json` file containing a `url` field.
 
 ```bash
-JARVIK_URL=http://example.com:8010 python -m tools.test_endpoint -m "ping"
+JARVIK_URL=http://example.com:8000 python -m tools.test_endpoint -m "ping"
 ```
 
 Example `devlab_config.json`:
 
 ```json
-{ "url": "http://example.com:8010" }
+{ "url": "http://example.com:8000" }
 ```
 
 With this file present you can simply run:

--- a/main.py
+++ b/main.py
@@ -34,7 +34,7 @@ from typing import Any
 # Allow custom model via environment variable
 MODEL_NAME = os.getenv("MODEL_NAME", "openchat")
 # Allow choosing the Flask port via environment variable
-FLASK_PORT = int(os.getenv("FLASK_PORT", 8010))
+FLASK_PORT = int(os.getenv("FLASK_PORT", 8000))
 # Allow choosing the Flask host via environment variable
 FLASK_HOST = os.getenv("FLASK_HOST", "0.0.0.0")
 # Base URL for the Ollama server

--- a/start_jarvik.sh
+++ b/start_jarvik.sh
@@ -4,7 +4,7 @@ RED="\033[1;31m"
 NC="\033[0m"
 
 # Allow overriding the Flask port
-FLASK_PORT=${FLASK_PORT:-8010}
+FLASK_PORT=${FLASK_PORT:-8000}
 
 cd "$(dirname "$0")" || exit
 

--- a/status.sh
+++ b/status.sh
@@ -3,7 +3,7 @@
 echo "🔍 Kontrola systému JARVIK..."
 
 MODEL_NAME=${MODEL_NAME:-"openchat"}
-FLASK_PORT=${FLASK_PORT:-8010}
+FLASK_PORT=${FLASK_PORT:-8000}
 
 is_windows() {
   case "$(uname -s)" in

--- a/tools/test_endpoint.py
+++ b/tools/test_endpoint.py
@@ -30,7 +30,7 @@ def get_target_url() -> str:
                 return str(data["url"]).rstrip("/")
         except Exception:
             pass
-    return "http://localhost:8010"
+    return "http://localhost:8000"
 
 
 def send_test_request(url: str, message: str) -> str:

--- a/tunel.sh
+++ b/tunel.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-FLASK_PORT=${FLASK_PORT:-8010}
+FLASK_PORT=${FLASK_PORT:-8000}
 
 command_exists() {
   command -v "$1" >/dev/null 2>&1
@@ -22,7 +22,7 @@ else
 fi
 
 # Allow overriding the Flask port
-FLASK_PORT=${FLASK_PORT:-8010}
+FLASK_PORT=${FLASK_PORT:-8000}
 
 # Check that the Jarvik server is responding on the given port
 CHECK_OK=0

--- a/watchdog.sh
+++ b/watchdog.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-FLASK_PORT=${FLASK_PORT:-8010}
+FLASK_PORT=${FLASK_PORT:-8000}
 MODEL_NAME=${MODEL_NAME:-"openchat"}
 MODEL_LOG="${MODEL_NAME//:/_}.log"
 


### PR DESCRIPTION
## Summary
- update default `FLASK_PORT` to 8000 in scripts and application
- change example URLs and docs to use port 8000

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bcff383688327809de4c942e09798