### PR TITLE
Fix unicode escapes in search output

### DIFF
--- a/tools/web_search.py
+++ b/tools/web_search.py
@@ -27,6 +27,6 @@ def search_and_scrape(query: str, max_results: int = 1) -> str:
         resp = requests.get(url, timeout=5, headers={"User-Agent": "Mozilla/5.0"})
         soup = BeautifulSoup(resp.text, "html.parser")
         text = soup.get_text(separator="\n", strip=True)
-        return f"\ud83d\udd17 {url}\n\n{text[:2000]}\u2026"
+        return f"🔗 {url}\n\n{text[:2000]}…"
     except Exception as e:  # pragma: no cover - network dependent
-        return f"\u274c Chyba p\u0159i na\u010d\u00edt\u00e1n\u00ed: {e}"
+        return f"❌ Chyba p\u0159i na\u010d\u00edt\u00e1n\u00ed: {e}"


### PR DESCRIPTION
## Summary
- show unicode link and ellipsis in the search result text
- use a unicode cross mark for errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c13366d9c8327b0e13476f05eaa49