### PR TITLE
Fix PowerShell quoting for Flask cleanup

### DIFF
--- a/start_flask.sh
+++ b/start_flask.sh
@@ -25,7 +25,7 @@ is_windows() {
 }
 
 if is_windows && command -v powershell.exe >/dev/null 2>&1; then
-  powershell.exe -Command "$p = Get-CimInstance Win32_Process | Where-Object { \$_.CommandLine -match 'main.py' }; if ($p) { \$p | ForEach-Object { Stop-Process -Id \$_.ProcessId -Force } }"
+  powershell.exe -Command "\$p = Get-CimInstance Win32_Process | Where-Object { \$_.CommandLine -match 'main.py' }; if (\$p) { \$p | ForEach-Object { Stop-Process -Id \$_.ProcessId -Force } }"
 else
   pkill -f "python.*${DIR}/main.py" 2>/dev/null || true
 fi

--- a/stop_all.sh
+++ b/stop_all.sh
@@ -13,7 +13,7 @@ is_windows() {
 if is_windows && command -v powershell.exe >/dev/null 2>&1; then
   powershell.exe -Command '$p=Get-Process -Name ollama -ErrorAction SilentlyContinue; if ($p) { $p | Stop-Process -Force; exit 0 } else { exit 1 }' && echo "Stopped ollama serve" || true
   powershell.exe -Command '$p=Get-Process -Name ollama -ErrorAction SilentlyContinue; if ($p) { $p | Stop-Process -Force; exit 0 } else { exit 1 }' && echo "Stopped running models" || true
-  powershell.exe -Command "$p = Get-CimInstance Win32_Process | Where-Object { \$_.CommandLine -match 'main.py' }; if ($p) { \$p | ForEach-Object { Stop-Process -Id \$_.ProcessId -Force }; exit 0 } else { exit 1 }" && echo "Stopped Flask" || true
+  powershell.exe -Command "\$p = Get-CimInstance Win32_Process | Where-Object { \$_.CommandLine -match 'main.py' }; if (\$p) { \$p | ForEach-Object { Stop-Process -Id \$_.ProcessId -Force }; exit 0 } else { exit 1 }" && echo "Stopped Flask" || true
 else
   pkill -f "ollama serve" 2>/dev/null && echo "Stopped ollama serve" || true
   pkill -f "ollama run" 2>/dev/null && echo "Stopped running models" || true


### PR DESCRIPTION
## Summary
- ensure `$p` variable is preserved in PowerShell commands
- update `start_flask.sh` and `stop_all.sh` to escape `$p`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ccf727eb48327b73b5f371b1fc8fe