### PR TITLE
Use timezone aware datetimes

### DIFF
--- a/main.py
+++ b/main.py
@@ -28,7 +28,7 @@ from filelock import FileLock
 import logging
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 from typing import Any
 
 # Allow custom model via environment variable
@@ -319,7 +319,7 @@ def _read_memory_file(folder: str) -> list[dict]:
 
         cutoff = None
         if MEMORY_RETENTION_DAYS > 0:
-            cutoff = datetime.utcnow() - timedelta(days=MEMORY_RETENTION_DAYS)
+            cutoff = datetime.now(UTC) - timedelta(days=MEMORY_RETENTION_DAYS)
         pending_user: str | None = None
         for line in lines:
             line = line.strip()
@@ -405,7 +405,7 @@ def append_to_memory(
 ) -> None:
     """Append a conversation entry to the memory log."""
 
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
     now_date = date or now.date().isoformat()
     now_time = time or now.time().isoformat(timespec="seconds")
     now_iso = f"{now_date}T{now_time}"
@@ -447,7 +447,7 @@ def append_to_memory(
             f.write(json.dumps(entry_user) + "\n")
             f.write(json.dumps(entry_assist) + "\n")
         if MEMORY_RETENTION_DAYS > 0:
-            cutoff = (datetime.utcnow() - timedelta(days=MEMORY_RETENTION_DAYS)).isoformat()
+            cutoff = (datetime.now(UTC) - timedelta(days=MEMORY_RETENTION_DAYS)).isoformat()
             if vymazat_memory_range(path, do=cutoff):
                 memory_caches[folder] = _read_memory_file(folder)
 
@@ -465,7 +465,7 @@ def _flush_memory_locked(folder: str) -> None:
     lines = cache
     with open(path, "w", encoding="utf-8") as f:
         for item in lines:
-            now = datetime.utcnow()
+            now = datetime.now(UTC)
             now_date = now.date().isoformat()
             now_time = now.time().isoformat(timespec="seconds")
             now_iso = f"{now_date}T{now_time}"

--- a/tests/test_flask_app.py
+++ b/tests/test_flask_app.py
@@ -169,9 +169,9 @@ def test_memory_search_with_invalid_line(client):
     import os
     import json
 
-    from datetime import datetime
+    from datetime import datetime, UTC
     path = os.path.join(main.MEMORY_DIR, "public.jsonl")
-    ts = datetime.utcnow().isoformat()
+    ts = datetime.now(UTC).isoformat()
     with open(path, "w", encoding="utf-8") as f:
         f.write(json.dumps({"timestamp": ts, "role": "user", "message": "ok"}) + "\n")
         f.write(json.dumps({"timestamp": ts, "role": "assistant", "message": "good"}) + "\n")
@@ -725,11 +725,11 @@ def test_read_memory_file_new_format(monkeypatch, tmp_path):
     import main
     import os
     import json
-    from datetime import datetime
+    from datetime import datetime, UTC
 
     monkeypatch.setattr(main, "MEMORY_DIR", str(tmp_path))
     path = os.path.join(main.MEMORY_DIR, "public.jsonl")
-    ts = datetime.utcnow().isoformat()
+    ts = datetime.now(UTC).isoformat()
     with open(path, "w", encoding="utf-8") as f:
         f.write(json.dumps({"timestamp": ts, "role": "user", "message": "q"}) + "\n")
         f.write(json.dumps({"timestamp": ts, "role": "assistant", "message": "a"}) + "\n")


### PR DESCRIPTION
## Summary
- use `datetime.now(datetime.UTC)` instead of deprecated `utcnow()`
- adjust imports to include `UTC`
- update tests for timezone-aware timestamps

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d146244b48327875438cb6b0a0076