### PR TITLE
Add knowledge cleanup script with uninstall flag

### DIFF
--- a/clean_knowledge.sh
+++ b/clean_knowledge.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$DIR" || exit
+set -e
+
+if [ ! -d knowledge ]; then
+  echo "❌ Složka knowledge neexistuje." >&2
+  exit 1
+fi
+
+cat <<'MSG'
+⚠️  Tento skript smaže vše v knowledge/ kromě souboru _index.json.
+   Provádí logiku podobnou příkazu:
+       rm -rf knowledge/*
+   Stiskněte Ctrl+C pro zrušení, nebo počkejte...
+MSG
+sleep 3
+
+find knowledge -mindepth 1 ! -name _index.json -exec rm -rf {} +
+
+echo "✅ Knowledge vyčištěno."
+

--- a/uninstall_jarvik.sh
+++ b/uninstall_jarvik.sh
@@ -5,6 +5,14 @@ set -e
 # Default model name can be overridden via MODEL_NAME
 MODEL_NAME=${MODEL_NAME:-"openchat"}
 
+# Optional flag to also clean knowledge base
+WITH_KNOWLEDGE=false
+for arg in "$@"; do
+  if [ "$arg" = "--with-knowledge" ]; then
+    WITH_KNOWLEDGE=true
+  fi
+done
+
 echo "🗑️ Odinstalace Jarvika..."
 
 # Kill running processes
@@ -16,6 +24,11 @@ pkill -f "python3 main.py" 2>/dev/null && echo "Zastaven Flask" || true
 rm -rf venv memory
 find . -name "__pycache__" -type d -exec rm -rf {} + 2>/dev/null
 rm -f *.log
+
+# If requested, also remove knowledge contents
+if [ "$WITH_KNOWLEDGE" = true ]; then
+  bash "$DIR/clean_knowledge.sh"
+fi
 
 # Remove aliases from ~/.bashrc
 sed -i '/# 🚀 Alias příkazy pro JARVIK/,+7d' ~/.bashrc


### PR DESCRIPTION
## Summary
- add `clean_knowledge.sh` to wipe `knowledge/` contents but keep `_index.json`
- make script executable
- extend `uninstall_jarvik.sh` with `--with-knowledge` flag for optional cleanup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d22aee5408327b5f5e4c0a60c257b