### PR TITLE
Handle cross-platform paths in knowledge API

### DIFF
--- a/main.py
+++ b/main.py
@@ -1023,6 +1023,7 @@ def knowledge_pending():
                 continue
             if meta.get("status") == "pending_approval":
                 rel = os.path.relpath(os.path.splitext(path)[0] + ".txt", base)
+                rel = rel.replace(os.sep, "/")
                 meta = dict(meta)
                 meta["file"] = rel
                 pending.append(meta)
@@ -1031,11 +1032,12 @@ def knowledge_pending():
 
 def _resolve_public_path(rel: str) -> str:
     rel = rel.lstrip("/\\")
+    rel = rel.replace("/", os.sep)
     full = os.path.abspath(os.path.join(PUBLIC_KNOWLEDGE_FOLDER, rel))
     base = os.path.abspath(PUBLIC_KNOWLEDGE_FOLDER)
     if os.path.commonpath([full, base]) != base:
         raise ValueError("invalid path")
-    return full
+    return os.path.normpath(full)
 
 
 @app.route("/knowledge/approve", methods=["POST"])


### PR DESCRIPTION
## Summary
- normalize path separators in `knowledge_pending`
- restore local path separators in `_resolve_public_path`
- ensure resulting paths are normalized

## Testing
- `pytest tests/test_flask_app.py::test_knowledge_pending_and_approve -q` *(fails: ERROR: found no collectors)*

------
https://chatgpt.com/codex/tasks/task_e_686d4caeb4288327a84d1e183fdc9040