### PR TITLE
Fix mobile page title grammar

### DIFF
--- a/static/mobile.html
+++ b/static/mobile.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
-{% block title %}Jarvik – mobile{% endblock %}
+{% block title %}Jarvik – mobil{% endblock %}
 
 {# Display a short message so that something is visible even before login #}
 {% block extra_body %}
-  <p style="text-align:center">Vítejte v mobilním rozhraní Jarvik.</p>
+  <p style="text-align:center">Vítejte v mobilním rozhraní Jarviku.</p>
 {% endblock %}


### PR DESCRIPTION
## Summary
- use Czech term "mobil" in `mobile.html` page title

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d6411978883278b313f55cfc84a7a