### PR TITLE
Switch to ddgs for web search

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -22,11 +22,11 @@ Výchozí umístění adresářů `memory/` a `knowledge/` lze změnit pomocí p
    bash install_jarvik.sh --clean
    ```
 
-2. Po skončení instalace zkontrolujte, že je k dispozici balíček `duckduckgo-search`
-    ve verzi 8.0 nebo novější. Pokud chybí, doinstalujte jej v aktivovaném
+2. Po skončení instalace zkontrolujte, že je k dispozici balíček `ddgs`.
+    Pokud chybí, doinstalujte jej v aktivovaném
     virtuálním prostředí příkazem:
    ```bash
-     pip install -U duckduckgo-search>=8.0
+     pip install -U ddgs
    ```
 
 3. Po dokončení instalace načtěte aliasy usnadňující práci se skripty:

--- a/README.md
+++ b/README.md
@@ -24,12 +24,11 @@ Install dependencies and create the virtual environment:
 bash install_jarvik.sh
 ```
 
-After running the installer, ensure the package `duckduckgo-search` is
-available in version 8.0 or newer. If needed, activate the virtual environment
-and run:
+After running the installer, ensure the package `ddgs` is installed. If needed,
+activate the virtual environment and run:
 
 ```bash
-pip install -U duckduckgo-search>=8.0
+pip install -U ddgs
 ```
 
 Make sure the commands `ollama`, `curl`, `lsof` and either `ss` (from

--- a/install_jarvik.sh
+++ b/install_jarvik.sh
@@ -66,10 +66,10 @@ if ! pip install -r requirements.txt; then
   exit 1
 fi
 
-# Upgrade duckduckgo-search to ensure latest version
-echo "⬆️  Aktualizuji duckduckgo-search..."
-if ! pip install -U 'duckduckgo-search>=8.0'; then
-  echo -e "\033[1;33m⚠️  Aktualizace duckduckgo-search selhala. Zkontrolujte připojení k internetu.\033[0m"
+# Upgrade ddgs to ensure latest version
+echo "⬆️  Aktualizuji ddgs..."
+if ! pip install -U ddgs; then
+  echo -e "\033[1;33m⚠️  Aktualizace ddgs selhala. Zkontrolujte připojení k internetu.\033[0m"
   exit 1
 fi
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 flask
 requests
 filelock
-duckduckgo-search>=8.0
+ddgs
 beautifulsoup4
 sentence-transformers
 faiss-cpu

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -2,7 +2,7 @@ import os
 import sys
 import pytest
 
-pytest.importorskip("duckduckgo_search")
+pytest.importorskip("ddgs")
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from tools import web_search
@@ -43,7 +43,7 @@ def test_search_and_scrape_handles_exception(monkeypatch):
             pass
 
         def text(self, q, max_results=1, **kwargs):
-            raise web_search.DuckDuckGoSearchException("ratelimit")
+            raise web_search.DDGSearchException("ratelimit")
 
     monkeypatch.setattr(web_search, "DDGS", DummyDDGS)
 

--- a/tools/web_search.py
+++ b/tools/web_search.py
@@ -1,8 +1,8 @@
 try:
-    from duckduckgo_search import DDGS, DuckDuckGoSearchException
-except ImportError:  # older versions don't expose DuckDuckGoSearchException
-    from duckduckgo_search import DDGS  # type: ignore
-    DuckDuckGoSearchException = Exception  # type: ignore
+    from ddgs import DDGS, DDGSearchException
+except ImportError:  # older versions don't expose DDGSearchException
+    from ddgs import DDGS  # type: ignore
+    DDGSearchException = Exception  # type: ignore
 import requests
 from bs4 import BeautifulSoup
 
@@ -17,7 +17,7 @@ def search_and_scrape(query: str, max_results: int = 1) -> str:
     with DDGS() as ddgs:
         try:
             results = list(ddgs.text(query, max_results=max_results))
-        except DuckDuckGoSearchException:
+        except DDGSearchException:
             results = []
     if not results:
         return "\u26a0\ufe0f \u017d\u00e1dn\u00e9 v\u00fdsledky nenalezeny."


### PR DESCRIPTION
## Summary
- use `ddgs` instead of deprecated `duckduckgo-search`
- update docs, installer script and dependencies
- adjust tests to expect the new library

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e0c6611c88327b376d1d64e465c46