### PR TITLE
Add configurable request timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ if you want to restrict connections to the local machine. Setting `FLASK_HOST` t
 running locally (defaults to `http://localhost:11434`). When `OLLAMA_URL`
 targets another host the start scripts will not attempt to launch a local
 Ollama instance and all `ollama` commands automatically use the remote server.
+Use `REQUEST_TIMEOUT` to control how long network requests wait for a
+response before failing (defaults to `10` seconds).
 
 ## Installation
 

--- a/main.py
+++ b/main.py
@@ -46,6 +46,7 @@ API_URL = os.getenv("API_URL", "https://api.openai.com/v1/chat/completions")
 API_MODEL = os.getenv("API_MODEL", os.getenv("OPENAI_MODEL", "gpt-3.5-turbo"))
 API_KEY = os.getenv("API_KEY")
 OPENAI_MODEL = API_MODEL  # backward compatibility
+REQUEST_TIMEOUT = int(os.getenv("REQUEST_TIMEOUT", 10))
 
 # Extended information about supported models. Each entry contains a label shown
 # in the UI, whether web search should be enabled and a short description.
@@ -107,7 +108,7 @@ def call_api(prompt: str, key: str | None = None) -> str:
         API_URL,
         headers=headers,
         json={"model": API_MODEL, "messages": [{"role": "user", "content": prompt}]},
-        timeout=10,
+        timeout=REQUEST_TIMEOUT,
     )
     resp.raise_for_status()
     data = resp.json()
@@ -599,7 +600,7 @@ def ask():
             response = requests.post(
                 f"{OLLAMA_URL}/api/generate",
                 json={"model": MODEL_NAME, "prompt": prompt, "stream": False},
-                timeout=10,
+                timeout=REQUEST_TIMEOUT,
             )
             response.raise_for_status()
             result = response.json()
@@ -662,7 +663,7 @@ def ask_web():
             response = requests.post(
                 f"{OLLAMA_URL}/api/generate",
                 json={"model": MODEL_NAME, "prompt": prompt, "stream": False},
-                timeout=10,
+                timeout=REQUEST_TIMEOUT,
             )
             response.raise_for_status()
             result = response.json()
@@ -746,7 +747,7 @@ def ask_file():
             response = requests.post(
                 f"{OLLAMA_URL}/api/generate",
                 json={"model": MODEL_NAME, "prompt": prompt, "stream": False},
-                timeout=10,
+                timeout=REQUEST_TIMEOUT,
             )
             response.raise_for_status()
             result = response.json()

--- a/tests/test_flask_app.py
+++ b/tests/test_flask_app.py
@@ -139,7 +139,7 @@ def test_ask_openai(client):
     res = client.post("/ask", json={"message": "hi"}, headers=headers)
     assert res.status_code == 200
     assert main._post_calls[-1][0] == main.API_URL
-    assert main._post_calls[-1][1]["timeout"] == 10
+    assert main._post_calls[-1][1]["timeout"] == main.REQUEST_TIMEOUT
 
 
 def test_memory_search(client):
@@ -303,7 +303,7 @@ def test_ask_auto_web_search(client, monkeypatch):
     res = client.post("/ask", json={"message": "hi"}, headers=_auth())
     assert res.status_code == 200
     assert calls
-    assert main._post_calls[-1][1]["timeout"] == 10
+    assert main._post_calls[-1][1]["timeout"] == main.REQUEST_TIMEOUT
     call = main._post_calls[-1][1]["json"]
     prompt = call.get("prompt") or call["messages"][0]["content"]
     assert "web" in prompt
@@ -445,7 +445,7 @@ def test_get_corrections_and_prompt_notes(client):
 
     res = client.post("/ask", json={"message": "hi"}, headers=_auth())
     assert res.status_code == 200
-    assert main._post_calls[-1][1]["timeout"] == 10
+    assert main._post_calls[-1][1]["timeout"] == main.REQUEST_TIMEOUT
     call = main._post_calls[-1][1]["json"]
     if "prompt" in call:
         prompt = call["prompt"]
@@ -486,7 +486,7 @@ def test_prompt_notes_with_mocked_file_and_similarity(client, monkeypatch):
 
     res = client.post("/ask", json={"message": "hi"}, headers=_auth())
     assert res.status_code == 200
-    assert main._post_calls[-1][1]["timeout"] == 10
+    assert main._post_calls[-1][1]["timeout"] == main.REQUEST_TIMEOUT
     call = main._post_calls[-1][1]["json"]
     prompt = call.get("prompt") or call["messages"][0]["content"]
     assert "Poznámka: note" in prompt


### PR DESCRIPTION
## Summary
- make request timeout configurable via `REQUEST_TIMEOUT` env var
- replace hard-coded HTTP timeouts in `main.py` with `REQUEST_TIMEOUT`
- adjust Flask app tests to check the constant
- document the new variable in the README

## Testing
- `pytest -q`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_686e113d1d38832793c8c8ee3f4027d1