### PR TITLE
Fix port_active checks for netstat and listening sockets

### DIFF
--- a/status.sh
+++ b/status.sh
@@ -19,11 +19,13 @@ command_exists() {
 port_active() {
   local port="$1"
   if command_exists ss; then
-    ss -tuln | grep -q ":$port"
+    ss -tuln | grep LISTEN | grep -q ":$port"
   elif command_exists lsof; then
     lsof -i ":$port" 2>/dev/null | grep -q LISTEN
+  elif command_exists netstat; then
+    netstat -an | grep LISTEN | grep -q ":$port"
   else
-    netstat -an | grep -q ":$port"
+    return 1
   fi
 }
 

--- a/watchdog.sh
+++ b/watchdog.sh
@@ -24,11 +24,13 @@ command_exists() {
 port_active() {
   local port="$1"
   if command_exists ss; then
-    ss -tuln | grep -q ":$port"
+    ss -tuln | grep LISTEN | grep -q ":$port"
   elif command_exists lsof; then
     lsof -i ":$port" 2>/dev/null | grep -q LISTEN
+  elif command_exists netstat; then
+    netstat -an | grep LISTEN | grep -q ":$port"
   else
-    netstat -an | grep -q ":$port"
+    return 1
   fi
 }
 


### PR DESCRIPTION
## Summary
- only detect listening ports in `status.sh` and `watchdog.sh`
- check for `netstat` before using it and return failure if no tools are available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e15183c488327aef1e91bad976fe9