### PR TITLE
Add FLASK_DEBUG variable

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -6,6 +6,7 @@ Ve výchozím nastavení je použit model `openchat`. Model lze kdykoli změnit 
 Flask API naslouchá na portu `8000`, který lze změnit proměnnou `FLASK_PORT`.
 Pro vzdálenou Ollamu nastavte proměnnou `OLLAMA_URL` (výchozí
 `http://localhost:11434`).
+Ladicí režim Flasku je zapnutý; vypnete jej nastavením `FLASK_DEBUG=false`.
 Citlivost vyhledávání ve znalostech můžete upravit proměnnou `RAG_THRESHOLD`
 (výchozí hodnota je `0.7`).
 Znalostní soubory lze nahrávat v rozhraní pomocí tlačítka "Nahrát". Ke každému souboru můžete uvést popis, který se uloží do paměti.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ running locally (defaults to `http://localhost:11434`). When `OLLAMA_URL`
 targets another host the start scripts will not attempt to launch a local
 Ollama instance and all `ollama` commands automatically use the remote server.
 Use `REQUEST_TIMEOUT` to control how long network requests wait for a
-response before failing (defaults to `10` seconds).
+response before failing (defaults to `10` seconds). The `FLASK_DEBUG`
+environment variable toggles Flask's debug mode and defaults to `true`.
 
 ## Installation
 

--- a/main.py
+++ b/main.py
@@ -37,6 +37,8 @@ MODEL_NAME = os.getenv("MODEL_NAME", "openchat")
 FLASK_PORT = int(os.getenv("FLASK_PORT", 8000))
 # Allow choosing the Flask host via environment variable
 FLASK_HOST = os.getenv("FLASK_HOST", "0.0.0.0")
+# Allow toggling Flask debug mode via environment variable
+FLASK_DEBUG = os.getenv("FLASK_DEBUG", "true").lower() in {"1", "true", "yes"}
 # Base URL for the Ollama server
 OLLAMA_URL = os.getenv("OLLAMA_URL", "http://localhost:11434")
 
@@ -1169,5 +1171,5 @@ def feedback():
     return jsonify({"status": "ok"})
 
 if __name__ == "__main__":
-    app.run(debug=True, host=FLASK_HOST, port=FLASK_PORT)
+    app.run(debug=FLASK_DEBUG, host=FLASK_HOST, port=FLASK_PORT)
 

--- a/start_flask.sh
+++ b/start_flask.sh
@@ -41,6 +41,7 @@ else
 fi
 
 # Spuštění Flasku
+# Např. FLASK_DEBUG=false bash start_flask.sh vypne debug mód
 python main.py &
 echo $! > "$PID_FILE"
 wait $!


### PR DESCRIPTION
## Summary
- expose a `FLASK_DEBUG` env var in `main.py`
- document `FLASK_DEBUG` in README and MANUAL
- note the env var in `start_flask.sh`

## Testing
- `ruff check --fix`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e1d8beb5483278206904eadf3ffc9