### PR TITLE
Auto open browser after startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ bash start_jarvik.sh
 The script checks for required commands and automatically downloads the
 `openchat` model if it is missing. Po spuštění vypíše, zda se všechny části
 správně nastartovaly, případné chyby hledejte v souborech `*.log`.
+Pokud vše proběhne bez chyb, otevře se výchozí prohlížeč na adrese
+`http://localhost:$FLASK_PORT/`. Nastavte proměnnou prostředí `NO_BROWSER=1`,
+pokud si nepřejete prohlížeč spouštět automaticky.
 With the aliases loaded you can simply type:
 
 ```bash

--- a/start_jarvik.sh
+++ b/start_jarvik.sh
@@ -65,6 +65,19 @@ process_running() {
   fi
 }
 
+# Helper to open the web interface in the default browser
+open_browser() {
+  local url="http://localhost:$FLASK_PORT/"
+  if is_windows; then
+    command -v cmd.exe >/dev/null 2>&1 && cmd.exe /C start "" "$url"
+  else
+    case "$(uname -s)" in
+      Darwin*) command -v open >/dev/null 2>&1 && open "$url" >/dev/null 2>&1 & ;;
+      *) command -v xdg-open >/dev/null 2>&1 && xdg-open "$url" >/dev/null 2>&1 & ;;
+    esac
+  fi
+}
+
 # Potřebujeme také 'ss' nebo 'nc' (případně BusyBox) pro kontrolu běžících portů
 SS_CMD=""
 NC_CMD=""
@@ -173,3 +186,6 @@ if [ "$PORT_OK" -ne 1 ]; then
   exit 1
 fi
 echo -e "${GREEN}✅ Jarvik běží na http://localhost:$FLASK_PORT${NC}"
+if [ -z "$NO_BROWSER" ]; then
+  open_browser
+fi


### PR DESCRIPTION
## Summary
- open the web UI automatically when `start_jarvik.sh` succeeds
- provide an `open_browser` helper for Linux/macOS/Windows
- allow disabling this by setting `NO_BROWSER`
- document new behaviour in README

## Testing
- `pytest -q`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_686e68eb4d508327b5beaa0e9bf5d79b