### PR TITLE
Remove manual start/stop routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,10 +304,9 @@ starts Flask you can also use the main start script:
 bash start_jarvik.sh
 ```
 
-Once the server is running you can control it directly from the web
-interface. The dashboard contains **Start Jarvik** and **Stop Jarvik**
-buttons which call the new `/start` and `/stop` endpoints to launch or
-terminate all components.
+Once the server is running it stays active in the background.
+Model switching is handled from the web interface using the
+**Switch model** control, which restarts Jarvik with the selected model.
 
 ## Real-time Monitoring
 
@@ -446,7 +445,7 @@ After logging in you will see the main dashboard with several panels and control
 5. **Answer panel** – the right panel shows the model response. Below it are buttons to mark the reply as good or bad and to send a correction. If saving is enabled a download link to the text file is displayed.
 6. **Additional panels** – context snippets and debug information are shown on the left. You can also expand the *Historie* section to view recent conversation history and inspect status messages.
 7. **Knowledge management** – further controls allow uploading new knowledge files, approving or rejecting pending uploads and deleting memory entries by time range or keyword.
-8. **Service control** – the *Start Jarvik* and *Stop Jarvik* buttons launch or terminate the background processes.
+8. **Service control** – Jarvik runs continuously. Use *Switch model* to restart it with a different model.
 9. **Logout** – use the *Logout* button at the bottom to remove the token and return to the login form.
 
 ## Running Tests

--- a/main.py
+++ b/main.py
@@ -1143,31 +1143,6 @@ def model_route():
     return jsonify({"status": "restarting", "model": new_model})
 
 
-@app.route("/start", methods=["POST"])
-@require_auth
-def start_route():
-    """Launch Jarvik by calling ``start_jarvik.sh`` when not running."""
-    if jarvik_running():
-        return jsonify({"status": "already running"})
-
-    script = os.path.join(BASE_DIR, "start_jarvik.sh")
-    try:
-        subprocess.Popen(["bash", script])
-    except Exception as e:
-        return jsonify({"error": str(e)}), 500
-    return jsonify({"status": "starting"})
-
-
-@app.route("/stop", methods=["POST"])
-@require_auth
-def stop_route():
-    """Stop all Jarvik processes using ``stop_all.sh``."""
-    script = os.path.join(BASE_DIR, "stop_all.sh")
-    try:
-        subprocess.Popen(["bash", script])
-    except Exception as e:
-        return jsonify({"error": str(e)}), 500
-    return jsonify({"status": "stopping"})
 
 @app.route("/")
 def index():

--- a/static/app.js
+++ b/static/app.js
@@ -440,43 +440,6 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  async function startJarvik() {
-    const status = document.getElementById('service-status');
-    if (status) status.textContent = '⏳ Spouštím…';
-    try {
-      const res = await fetch('/start', {
-        method: 'POST',
-        headers: authHeader()
-      });
-      const data = await safeJson(res);
-      if (res.ok) {
-        if (status) status.textContent = '✅ Spouštím';
-      } else if (status) {
-        status.textContent = '❌ ' + (data.error || res.status);
-      }
-    } catch (err) {
-      if (status) status.textContent = '❌ ' + err;
-    }
-  }
-
-  async function stopJarvik() {
-    const status = document.getElementById('service-status');
-    if (status) status.textContent = '⏳ Zastavuji…';
-    try {
-      const res = await fetch('/stop', {
-        method: 'POST',
-        headers: authHeader()
-      });
-      const data = await safeJson(res);
-      if (res.ok) {
-        if (status) status.textContent = '✅ Zastavuji';
-      } else if (status) {
-        status.textContent = '❌ ' + (data.error || res.status);
-      }
-    } catch (err) {
-      if (status) status.textContent = '❌ ' + err;
-    }
-  }
 
   function logout() {
     localStorage.removeItem('token');
@@ -516,8 +479,6 @@ document.addEventListener('DOMContentLoaded', () => {
   window.rejectPending = rejectPending;
   window.deleteByTime = deleteByTime;
   window.deleteByKeyword = deleteByKeyword;
-  window.startJarvik = startJarvik;
-  window.stopJarvik = stopJarvik;
   window.logout = logout;
 
   const modelSelect = document.getElementById('model-select');

--- a/static/base.html
+++ b/static/base.html
@@ -171,8 +171,6 @@
 
     <pre id="token-display"></pre>
     <button id="copy-token-btn" onclick="copyToken()">Copy token</button>
-    <button onclick="startJarvik()">Start Jarvik</button>
-    <button onclick="stopJarvik()">Stop Jarvik</button>
     <pre id="service-status"></pre>
     <button onclick="logout()">Logout</button>
 


### PR DESCRIPTION
## Summary
- drop `/start` and `/stop` endpoints from Flask app
- remove `startJarvik` and `stopJarvik` code from client script
- delete buttons that called those functions
- document that Jarvik runs continuously and only model switching restarts it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f4f9e37748327bd0491b609abba2d