### PR TITLE
Improve Windows compatibility for kill scripts

### DIFF
--- a/switch_model.sh
+++ b/switch_model.sh
@@ -12,10 +12,23 @@ fi
 
 echo "🔄 Switching to model $NEW_MODEL..."
 
-# Stop running services
-pkill -f "python3 main.py" 2>/dev/null
-pkill -f "ollama run" 2>/dev/null
-pkill -f "ollama serve" 2>/dev/null
+# Stop running services across platforms
+is_windows() {
+  case "$(uname -s)" in
+    CYGWIN*|MINGW*|MSYS*) return 0 ;;
+  esac
+  [ "$OS" = "Windows_NT" ]
+}
+
+if is_windows && command -v powershell.exe >/dev/null 2>&1; then
+  powershell.exe -Command '$p=Get-Process -Name ollama -ErrorAction SilentlyContinue; if ($p) { $p | Stop-Process -Force; exit 0 } else { exit 1 }'
+  powershell.exe -Command '$p=Get-Process -Name ollama -ErrorAction SilentlyContinue; if ($p) { $p | Stop-Process -Force; exit 0 } else { exit 1 }'
+  powershell.exe -Command "\$p = Get-CimInstance Win32_Process | Where-Object {\$_.CommandLine -match 'main.py' }; if (\$p) { \$p | ForEach-Object { Stop-Process -Id \$_.ProcessId -Force } }"
+else
+  pkill -f "python3 main.py" 2>/dev/null
+  pkill -f "ollama run" 2>/dev/null
+  pkill -f "ollama serve" 2>/dev/null
+fi
 sleep 2
 
 if [ "$NEW_MODEL" = "api" ]; then

--- a/uninstall_jarvik.sh
+++ b/uninstall_jarvik.sh
@@ -15,10 +15,23 @@ done
 
 echo "🗑️ Odinstalace Jarvika..."
 
-# Kill running processes
-pkill -f "ollama serve" 2>/dev/null && echo "Zastaven ollama serve" || true
-pkill -f "ollama run" 2>/dev/null && echo "Zastaveny modely" || true
-pkill -f "python3 main.py" 2>/dev/null && echo "Zastaven Flask" || true
+# Kill running processes on both Linux and Windows
+is_windows() {
+  case "$(uname -s)" in
+    CYGWIN*|MINGW*|MSYS*) return 0 ;;
+  esac
+  [ "$OS" = "Windows_NT" ]
+}
+
+if is_windows && command -v powershell.exe >/dev/null 2>&1; then
+  powershell.exe -Command '$p=Get-Process -Name ollama -ErrorAction SilentlyContinue; if ($p) { $p | Stop-Process -Force; exit 0 } else { exit 1 }' && echo "Zastaven ollama serve" || true
+  powershell.exe -Command '$p=Get-Process -Name ollama -ErrorAction SilentlyContinue; if ($p) { $p | Stop-Process -Force; exit 0 } else { exit 1 }' && echo "Zastaveny modely" || true
+  powershell.exe -Command "\$p = Get-CimInstance Win32_Process | Where-Object {\$_.CommandLine -match 'main.py' }; if (\$p) { \$p | ForEach-Object { Stop-Process -Id \$_.ProcessId -Force } }" && echo "Zastaven Flask" || true
+else
+  pkill -f "ollama serve" 2>/dev/null && echo "Zastaven ollama serve" || true
+  pkill -f "ollama run" 2>/dev/null && echo "Zastaveny modely" || true
+  pkill -f "python3 main.py" 2>/dev/null && echo "Zastaven Flask" || true
+fi
 
 # Remove directories and logs
 rm -rf venv memory


### PR DESCRIPTION
## Summary
- handle Windows process termination in `uninstall_jarvik.sh`
- add Windows process termination logic in `switch_model.sh`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f5f696be48327b415fb867c54eea2