### PR TITLE
Enable CORS for Flask API

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,22 @@ directories inside the `backups/` folder (e.g.
 `backups/backup_20240517_153000.tar.gz`). To restore data simply extract the
 desired archive in the repository root.
 
+## API Setup
+
+The Flask server enables Cross-Origin Resource Sharing (CORS) so web
+applications can call the API from other domains. The feature is provided by
+the `flask-cors` package and activated in `main.py`:
+
+```python
+from flask_cors import CORS
+
+app = Flask(__name__, static_folder="static", template_folder="static")
+CORS(app)
+```
+
+All origins are allowed by default. You can restrict access with
+`CORS(app, resources={r"/*": {"origins": "https://example.com"}})` if needed.
+
 ## API Usage
 
 Jarvik exposes a few HTTP endpoints on the configured Flask port

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ from flask import (
     url_for,
     render_template,
 )
+from flask_cors import CORS
 from werkzeug.utils import secure_filename
 from memory import vymazat_memory_range, _parse_dt
 from rag_engine import (
@@ -325,6 +326,7 @@ MEMORY_RETENTION_DAYS = int(os.getenv("MEMORY_RETENTION_DAYS", "7"))
 # Jarvik keeps conversation history for a limited time.
 
 app = Flask(__name__, static_folder="static", template_folder="static")
+CORS(app)
 
 # Načti znalosti při startu
 KNOWLEDGE_DIR = os.getenv("KNOWLEDGE_DIR", os.path.join(BASE_DIR, "knowledge"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 flask
+flask-cors
 requests
 filelock
 ddgs>=9.0.0


### PR DESCRIPTION
## Summary
- add `flask-cors` to requirements
- enable CORS in `main.py`
- document CORS configuration in README

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870a7859aa8832785092937ad8a73a6