### PR TITLE
Add /ask message validation

### DIFF
--- a/main.py
+++ b/main.py
@@ -622,6 +622,8 @@ def ask():
     data = request.get_json(silent=True)
     data = data or {}
     message = data.get("message", "")
+    if not message:
+        return jsonify({"error": "message required"}), 400
     api_key = request.headers.get("X-API-Key") or data.get("api_key")
     if not api_key and MODEL_MODE == "api":
         api_key = API_KEY

--- a/tests/test_flask_app.py
+++ b/tests/test_flask_app.py
@@ -154,6 +154,12 @@ def test_ask_openai(client):
     assert main._post_calls[-1][1]["timeout"] == main.REQUEST_TIMEOUT
 
 
+def test_ask_requires_message(client):
+    res = client.post("/ask", json={}, headers=_auth())
+    assert res.status_code == 400
+    assert res.get_json()["error"] == "message required"
+
+
 def test_memory_search(client):
     res = client.get("/memory/search", headers=_auth())
     assert res.status_code == 200


### PR DESCRIPTION
## Summary
- handle missing `message` in `/ask` endpoint and return 400
- test for missing message in `/ask`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870a8e2a4fc83278626847ee03b08c4