### PR TITLE
Add debug toggle for ask endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,10 @@ All origins are allowed by default. You can restrict access with
 Jarvik exposes a few HTTP endpoints on the configured Flask port
 (default `8000`) that can be consumed by external applications such as ChatGPT:
 
-* `POST /ask` – ask Jarvik a question. The conversation is stored in memory.
+* `POST /ask` – ask Jarvik a question. The conversation is stored in memory. Use
+  `?debug=1` or an `X-Debug: 1` header to include debugging details in the
+  response.
+  The same flag works for `/ask_web` and `/ask_file`.
 * `POST /memory/add` – manually append a `{ "user": "...", "jarvik": "..." }`
   record to the memory log.
 * `GET /memory/search?q=term` – search stored memory entries. When no query is

--- a/tests/test_flask_app.py
+++ b/tests/test_flask_app.py
@@ -338,6 +338,21 @@ def test_ask_auto_web_search(client, monkeypatch):
     assert "web" in prompt
 
 
+def test_debug_header(client):
+    res = client.post("/ask", json={"message": "hi"}, headers={**_auth(), "X-Debug": "1"})
+    assert res.status_code == 200
+    data = res.get_json()
+    assert "debug" in data and isinstance(data["debug"], list)
+
+
+def test_debug_query_param(client, monkeypatch):
+    import main
+    monkeypatch.setattr(main, "search_and_scrape", lambda q: "web")
+    res = client.post("/ask_web?debug=true", json={"message": "hi"}, headers=_auth())
+    assert res.status_code == 200
+    assert "debug" in res.get_json()
+
+
 def test_memory_add(client):
     import main
     res = client.post(


### PR DESCRIPTION
## Summary
- add optional `X-Debug` header or `debug` query parameter
- include debug log in responses only when requested
- document debug flag in README
- test debug toggle for `/ask` and `/ask_web`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870ab98273c83279afee1a8859eaeb7