### PR TITLE
Add debug parameter docs to API spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,8 +387,8 @@ Jarvik exposes a few HTTP endpoints on the configured Flask port
 
 * `POST /ask` – ask Jarvik a question. The conversation is stored in memory. Use
   `?debug=1` or an `X-Debug: 1` header to include debugging details in the
-  response.
-  The same flag works for `/ask_web` and `/ask_file`.
+  response. Values `1`, `true`, or `yes` are accepted. The same flag works for
+  `/ask_web` and `/ask_file`.
 * `POST /memory/add` – manually append a `{ "user": "...", "jarvik": "..." }`
   record to the memory log.
 * `GET /memory/search?q=term` – search stored memory entries. When no query is

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -48,9 +48,21 @@ paths:
   /ask:
     post:
       summary: Ask the assistant a question.
+      description: Set `debug` query parameter or `X-Debug` header to `1`, `true`, or `yes` to include debug information.
       security:
         - BasicAuth: []
         - BearerAuth: []
+      parameters:
+        - name: debug
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: X-Debug
+          in: header
+          required: false
+          schema:
+            type: string
       requestBody:
         required: true
         content:
@@ -83,9 +95,21 @@ paths:
   /ask_web:
     post:
       summary: Ask the assistant with mandatory web search.
+      description: Set `debug` query parameter or `X-Debug` header to `1`, `true`, or `yes` to include debug information.
       security:
         - BasicAuth: []
         - BearerAuth: []
+      parameters:
+        - name: debug
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: X-Debug
+          in: header
+          required: false
+          schema:
+            type: string
       requestBody:
         required: true
         content:
@@ -109,9 +133,21 @@ paths:
   /ask_file:
     post:
       summary: Ask the assistant with an optional file upload.
+      description: Set `debug` query parameter or `X-Debug` header to `1`, `true`, or `yes` to include debug information.
       security:
         - BasicAuth: []
         - BearerAuth: []
+      parameters:
+        - name: debug
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: X-Debug
+          in: header
+          required: false
+          schema:
+            type: string
       requestBody:
         required: true
         content:


### PR DESCRIPTION
## Summary
- document optional debug query parameter and `X-Debug` header for `/ask`, `/ask_web` and `/ask_file`
- clarify acceptable debug flag values in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870b3788ea48327a7b64285d8f69922