### PR TITLE
Add API key header documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,8 @@ Jarvik exposes a few HTTP endpoints on the configured Flask port
 * `POST /ask` – ask Jarvik a question. The conversation is stored in memory. Use
   `?debug=1` or an `X-Debug: 1` header to include debugging details in the
   response. Values `1`, `true`, or `yes` are accepted. The same flag works for
-  `/ask_web` and `/ask_file`.
+  `/ask_web` and `/ask_file`. An optional `X-API-Key` header overrides the
+  configured API key for a single request when running in API mode.
 * `POST /memory/add` – manually append a `{ "user": "...", "jarvik": "..." }`
   record to the memory log.
 * `GET /memory/search?q=term` – search stored memory entries. When no query is

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -63,6 +63,11 @@ paths:
           required: false
           schema:
             type: string
+        - name: X-API-Key
+          in: header
+          required: false
+          schema:
+            type: string
       requestBody:
         required: true
         content:
@@ -110,6 +115,11 @@ paths:
           required: false
           schema:
             type: string
+        - name: X-API-Key
+          in: header
+          required: false
+          schema:
+            type: string
       requestBody:
         required: true
         content:
@@ -144,6 +154,11 @@ paths:
           schema:
             type: string
         - name: X-Debug
+          in: header
+          required: false
+          schema:
+            type: string
+        - name: X-API-Key
           in: header
           required: false
           schema:


### PR DESCRIPTION
## Summary
- allow passing an `X-API-Key` header to `/ask`, `/ask_web`, and `/ask_file`
- document the header in the API usage section

## Testing
- `pytest`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_6870b4562ef48327a61b54197c106453